### PR TITLE
Annotate Rails Code With DB Schemas

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ gem "sentry-ruby"
 gem "sentry-rails"
 
 group :development, :test do
+  gem 'annotate'
   gem 'byebug'
   gem 'pry'
   gem 'jasmine-rails' # if you plan to use JavaScript/CoffeeScript

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,6 +44,9 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
+    annotate (3.1.1)
+      activerecord (>= 3.2, < 7.0)
+      rake (>= 10.4, < 14.0)
     arel (9.0.0)
     arrayfields (4.9.2)
     ast (2.4.2)
@@ -422,6 +425,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  annotate
   attr_encrypted (~> 3.1.0)
   byebug
   cucumber-rails

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -1,3 +1,22 @@
+# == Schema Information
+#
+# Table name: admins
+#
+#  id                                :bigint           not null, primary key
+#  email                             :string
+#  encrypted_google_refresh_token    :string
+#  encrypted_google_refresh_token_iv :string
+#  encrypted_google_token            :string
+#  encrypted_google_token_iv         :string
+#  first_name                        :string
+#  last_name                         :string
+#  created_at                        :datetime
+#  updated_at                        :datetime
+#
+# Indexes
+#
+#  index_admins_on_emails_and_first_name  (email,first_name)
+#
 class Admin < ApplicationRecord
   validates :first_name, :last_name, :email, presence: true
 

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -1,4 +1,25 @@
 # frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: schools
+#
+#  id                     :bigint           not null, primary key
+#  city                   :string
+#  lat                    :float
+#  lng                    :float
+#  name                   :string
+#  num_validated_teachers :integer          default(0)
+#  state                  :string
+#  teachers_count         :integer          default(0)
+#  website                :string
+#  created_at             :datetime         default(Wed, 11 Dec 2019 07:35:22 UTC +00:00)
+#  updated_at             :datetime         default(Wed, 11 Dec 2019 07:35:22 UTC +00:00)
+#
+# Indexes
+#
+#  index_schools_on_name_city_and_website  (name,city,website)
+#
 require 'uri'
 class School < ApplicationRecord
   validates :name, :city, :state, :website, presence: true

--- a/app/models/teacher.rb
+++ b/app/models/teacher.rb
@@ -1,5 +1,32 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: teachers
+#
+#  id                      :bigint           not null, primary key
+#  admin                   :boolean          default(FALSE)
+#  course                  :string
+#  email                   :string
+#  first_name              :string
+#  google_refresh_token    :string
+#  google_refresh_token_iv :string
+#  google_token            :string
+#  google_token_iv         :string
+#  last_name               :string
+#  more_info               :string
+#  other                   :string
+#  snap                    :string
+#  status                  :integer
+#  validated               :boolean
+#  created_at              :datetime
+#  updated_at              :datetime
+#  school_id               :integer
+#
+# Indexes
+#
+#  index_teachers_on_email_and_first_name  (email,first_name)
+#
 class Teacher < ApplicationRecord
   validates :first_name, :last_name, :email, :status, presence: true
   validates_inclusion_of :validated, :in => [true, false]

--- a/lib/tasks/auto_annotate_models.rake
+++ b/lib/tasks/auto_annotate_models.rake
@@ -1,0 +1,59 @@
+# NOTE: only doing this in development as some production environments (Heroku)
+# NOTE: are sensitive to local FS writes, and besides -- it's just not proper
+# NOTE: to have a dev-mode tool do its thing in production.
+if Rails.env.development?
+  require 'annotate'
+  task :set_annotation_options do
+    # You can override any of these by setting an environment variable of the
+    # same name.
+    Annotate.set_defaults(
+      'active_admin'                => 'false',
+      'additional_file_patterns'    => [],
+      'routes'                      => 'false',
+      'models'                      => 'true',
+      'position_in_routes'          => 'before',
+      'position_in_class'           => 'before',
+      'position_in_test'            => 'before',
+      'position_in_fixture'         => 'before',
+      'position_in_factory'         => 'before',
+      'position_in_serializer'      => 'before',
+      'show_foreign_keys'           => 'true',
+      'show_complete_foreign_keys'  => 'false',
+      'show_indexes'                => 'true',
+      'simple_indexes'              => 'false',
+      'model_dir'                   => 'app/models',
+      'root_dir'                    => '',
+      'include_version'             => 'false',
+      'require'                     => '',
+      'exclude_tests'               => 'false',
+      'exclude_fixtures'            => 'false',
+      'exclude_factories'           => 'false',
+      'exclude_serializers'         => 'false',
+      'exclude_scaffolds'           => 'true',
+      'exclude_controllers'         => 'true',
+      'exclude_helpers'             => 'true',
+      'exclude_sti_subclasses'      => 'false',
+      'ignore_model_sub_dir'        => 'false',
+      'ignore_columns'              => nil,
+      'ignore_routes'               => nil,
+      'ignore_unknown_models'       => 'false',
+      'hide_limit_column_types'     => 'integer,bigint,boolean',
+      'hide_default_column_types'   => 'json,jsonb,hstore',
+      'skip_on_db_migrate'          => 'false',
+      'format_bare'                 => 'true',
+      'format_rdoc'                 => 'false',
+      'format_yard'                 => 'false',
+      'format_markdown'             => 'false',
+      'sort'                        => 'false',
+      'force'                       => 'false',
+      'frozen'                      => 'false',
+      'classified_sort'             => 'true',
+      'trace'                       => 'false',
+      'wrapper_open'                => nil,
+      'wrapper_close'               => nil,
+      'with_comment'                => 'true'
+    )
+  end
+
+  Annotate.load_tasks
+end

--- a/spec/fixtures/admins.yml
+++ b/spec/fixtures/admins.yml
@@ -1,4 +1,22 @@
-# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+# == Schema Information
+#
+# Table name: admins
+#
+#  id                                :bigint           not null, primary key
+#  email                             :string
+#  encrypted_google_refresh_token    :string
+#  encrypted_google_refresh_token_iv :string
+#  encrypted_google_token            :string
+#  encrypted_google_token_iv         :string
+#  first_name                        :string
+#  last_name                         :string
+#  created_at                        :datetime
+#  updated_at                        :datetime
+#
+# Indexes
+#
+#  index_admins_on_emails_and_first_name  (email,first_name)
+#
 
 admin:
   first_name: Admin

--- a/spec/fixtures/schools.yml
+++ b/spec/fixtures/schools.yml
@@ -1,4 +1,23 @@
-# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+# == Schema Information
+#
+# Table name: schools
+#
+#  id                     :bigint           not null, primary key
+#  city                   :string
+#  lat                    :float
+#  lng                    :float
+#  name                   :string
+#  num_validated_teachers :integer          default(0)
+#  state                  :string
+#  teachers_count         :integer          default(0)
+#  website                :string
+#  created_at             :datetime         default(Wed, 11 Dec 2019 07:35:22 UTC +00:00)
+#  updated_at             :datetime         default(Wed, 11 Dec 2019 07:35:22 UTC +00:00)
+#
+# Indexes
+#
+#  index_schools_on_name_city_and_website  (name,city,website)
+#
 
 berkeley:
   name: UC Berkeley

--- a/spec/fixtures/teachers.yml
+++ b/spec/fixtures/teachers.yml
@@ -1,4 +1,30 @@
-# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+# == Schema Information
+#
+# Table name: teachers
+#
+#  id                      :bigint           not null, primary key
+#  admin                   :boolean          default(FALSE)
+#  course                  :string
+#  email                   :string
+#  first_name              :string
+#  google_refresh_token    :string
+#  google_refresh_token_iv :string
+#  google_token            :string
+#  google_token_iv         :string
+#  last_name               :string
+#  more_info               :string
+#  other                   :string
+#  snap                    :string
+#  status                  :integer
+#  validated               :boolean
+#  created_at              :datetime
+#  updated_at              :datetime
+#  school_id               :integer
+#
+# Indexes
+#
+#  index_teachers_on_email_and_first_name  (email,first_name)
+#
 
 ye:
   first_name: Ye

--- a/spec/models/teacher_spec.rb
+++ b/spec/models/teacher_spec.rb
@@ -1,3 +1,30 @@
+# == Schema Information
+#
+# Table name: teachers
+#
+#  id                      :bigint           not null, primary key
+#  admin                   :boolean          default(FALSE)
+#  course                  :string
+#  email                   :string
+#  first_name              :string
+#  google_refresh_token    :string
+#  google_refresh_token_iv :string
+#  google_token            :string
+#  google_token_iv         :string
+#  last_name               :string
+#  more_info               :string
+#  other                   :string
+#  snap                    :string
+#  status                  :integer
+#  validated               :boolean
+#  created_at              :datetime
+#  updated_at              :datetime
+#  school_id               :integer
+#
+# Indexes
+#
+#  index_teachers_on_email_and_first_name  (email,first_name)
+#
 require 'rails_helper'
 
 RSpec.describe Teacher, type: :model do

--- a/test/fixtures/schools.yml
+++ b/test/fixtures/schools.yml
@@ -1,4 +1,23 @@
-# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+# == Schema Information
+#
+# Table name: schools
+#
+#  id                     :bigint           not null, primary key
+#  city                   :string
+#  lat                    :float
+#  lng                    :float
+#  name                   :string
+#  num_validated_teachers :integer          default(0)
+#  state                  :string
+#  teachers_count         :integer          default(0)
+#  website                :string
+#  created_at             :datetime         default(Wed, 11 Dec 2019 07:35:22 UTC +00:00)
+#  updated_at             :datetime         default(Wed, 11 Dec 2019 07:35:22 UTC +00:00)
+#
+# Indexes
+#
+#  index_schools_on_name_city_and_website  (name,city,website)
+#
 
 berkeley:
   name: UC Berkeley

--- a/test/fixtures/teachers.yml
+++ b/test/fixtures/teachers.yml
@@ -1,4 +1,30 @@
-# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+# == Schema Information
+#
+# Table name: teachers
+#
+#  id                      :bigint           not null, primary key
+#  admin                   :boolean          default(FALSE)
+#  course                  :string
+#  email                   :string
+#  first_name              :string
+#  google_refresh_token    :string
+#  google_refresh_token_iv :string
+#  google_token            :string
+#  google_token_iv         :string
+#  last_name               :string
+#  more_info               :string
+#  other                   :string
+#  snap                    :string
+#  status                  :integer
+#  validated               :boolean
+#  created_at              :datetime
+#  updated_at              :datetime
+#  school_id               :integer
+#
+# Indexes
+#
+#  index_teachers_on_email_and_first_name  (email,first_name)
+#
 
 ye:
   first_name: Ye


### PR DESCRIPTION
This is helpful automatic "documentation".
Whenever you modify the schema, the model defs should be automatically
updated. You can always run `rake annotate_models` to
manually update the annotations.