### PR TITLE
Fix email template reseed problem

### DIFF
--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -1,6 +1,6 @@
 name: All Specs
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   specs:

--- a/app/controllers/email_templates_controller.rb
+++ b/app/controllers/email_templates_controller.rb
@@ -14,8 +14,13 @@ class EmailTemplatesController < ApplicationController
   def update
     template = EmailTemplate.find(params[:id])
     template.update(template_params)
-    template.save!
-    redirect_to email_templates_path
+    if template.save
+      flash[:success] = "Updated #{template.title} template successfully."
+      redirect_to email_templates_path
+    else
+      flash[:alert] = "Failed to save #{template.title} template: " + template.errors.full_messages.join(", ")
+      redirect_to edit_email_template_path(params[:id])
+    end
   end
 
   def create
@@ -27,11 +32,11 @@ class EmailTemplatesController < ApplicationController
     end
     load_ordered_email_templates
 
-    if @email_template.save!
+    if @email_template.save
       flash[:success] = "Created #{@email_template.title} successfully."
       redirect_to email_templates_path
     else
-      flash[:alert] = "Failed to submit information :("
+      flash[:alert] = "Failed to submit information: " + @email_template.errors.full_messages.join(", ")
       render "new"
     end
   end
@@ -49,7 +54,7 @@ class EmailTemplatesController < ApplicationController
 
   private
   def template_params
-    params.require(:email_template).permit(:body, :subject, :title)
+    params.require(:email_template).permit(:body, :subject, :title, :to)
   end
 
   def load_ordered_email_templates

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -95,6 +95,7 @@ class PagesController < ApplicationController
   #     teacher_school_website: @teacher.school.website,
   #     piazza_password: Rails.application.secrets[:piazza_password],
   #     denial_reason: @denial_reason
+  #     request_reason: @request_reason
   #   }.with_indifferent_access
   # end
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -94,7 +94,7 @@ class PagesController < ApplicationController
   #     teacher_snap: @teacher.snap,
   #     teacher_school_website: @teacher.school.website,
   #     piazza_password: Rails.application.secrets[:piazza_password],
-  #     reason: @reason
+  #     denial_reason: @denial_reason
   #   }.with_indifferent_access
   # end
 

--- a/app/controllers/teachers_controller.rb
+++ b/app/controllers/teachers_controller.rb
@@ -130,7 +130,7 @@ class TeachersController < ApplicationController
   def request_info
     @teacher.info_needed!
     if !params[:skip_email].present?
-      TeacherMailer.request_info_email(@teacher, params[:reason]).deliver_now
+      TeacherMailer.request_info_email(@teacher, params[:denial_reason]).deliver_now
     end
     redirect_to root_path
   end
@@ -146,7 +146,7 @@ class TeachersController < ApplicationController
     @teacher.denied!
     if !params[:skip_email].present?
       # TODO: Update dropdown to select the email template.
-      TeacherMailer.deny_email(@teacher, params[:reason]).deliver_now
+      TeacherMailer.deny_email(@teacher, params[:denial_reason]).deliver_now
     end
     redirect_to root_path
   end

--- a/app/controllers/teachers_controller.rb
+++ b/app/controllers/teachers_controller.rb
@@ -160,7 +160,12 @@ class TeachersController < ApplicationController
   def resend_welcome_email
     if @teacher.validated? || @is_admin
       TeacherMailer.welcome_email(@teacher).deliver_now
+      flash[:success] = "Welcome email resent successfully!"
+    else
+      flash[:alert] = "Error resending welcome email. \
+      Please ensure that your account has been validated by an administrator."
     end
+    redirect_to edit_teacher_path(@teacher)
   end
 
   def import

--- a/app/controllers/teachers_controller.rb
+++ b/app/controllers/teachers_controller.rb
@@ -130,7 +130,7 @@ class TeachersController < ApplicationController
   def request_info
     @teacher.info_needed!
     if !params[:skip_email].present?
-      TeacherMailer.request_info_email(@teacher, params[:denial_reason]).deliver_now
+      TeacherMailer.request_info_email(@teacher, params[:request_reason]).deliver_now
     end
     redirect_to root_path
   end
@@ -146,6 +146,7 @@ class TeachersController < ApplicationController
     @teacher.denied!
     if !params[:skip_email].present?
       # TODO: Update dropdown to select the email template.
+      puts params[:denial_reason]
       TeacherMailer.deny_email(@teacher, params[:denial_reason]).deliver_now
     end
     redirect_to root_path

--- a/app/controllers/teachers_controller.rb
+++ b/app/controllers/teachers_controller.rb
@@ -160,13 +160,12 @@ class TeachersController < ApplicationController
 
   def resend_welcome_email
     if @teacher.validated? || @is_admin
-      TeacherMailer.welcome_email(@teacher).deliver_now
       flash[:success] = "Welcome email resent successfully!"
+      TeacherMailer.welcome_email(@teacher).deliver_now
     else
-      flash[:alert] = "Error resending welcome email. \
-      Please ensure that your account has been validated by an administrator."
+      flash[:alert] = "Error resending welcome email. Please ensure that your account has been validated by an administrator."
     end
-    redirect_to edit_teacher_path(@teacher)
+    redirect_back(fallback_location: dashboard_path)
   end
 
   def import

--- a/app/mailers/teacher_mailer.rb
+++ b/app/mailers/teacher_mailer.rb
@@ -48,7 +48,9 @@ class TeacherMailer < ApplicationMailer
     base_rules = {
       bjc_password: Rails.application.secrets[:bjc_password],
       piazza_password: Rails.application.secrets[:piazza_password],
-      denial_reason: @denial_reason
+      # TODO: Review if below two are needed, or can they be refractored?
+      denial_reason: @denial_reason,
+      request_reason: @request_reason
     }
     base_rules.merge!(@teacher.email_attributes)
     base_rules.with_indifferent_access

--- a/app/mailers/teacher_mailer.rb
+++ b/app/mailers/teacher_mailer.rb
@@ -11,7 +11,8 @@ class TeacherMailer < ApplicationMailer
   def welcome_email(teacher)
     @teacher = teacher
     set_body
-    mail to: teacher.email_name,
+    set_recipients
+    mail to: @recipients, # ActionMailer accepts comma-separated lists of emails
          cc: CONTACT_EMAIL,
          subject: email_template.subject
   end
@@ -20,7 +21,8 @@ class TeacherMailer < ApplicationMailer
     @teacher = teacher
     @denial_reason = denial_reason
     set_body
-    mail to: @teacher.email_name,
+    set_recipients
+    mail to: @recipients,
          cc: CONTACT_EMAIL,
          subject: email_template.subject
   end
@@ -29,7 +31,8 @@ class TeacherMailer < ApplicationMailer
     @teacher = teacher
     @request_reason = request_reason
     set_body
-    mail to: @teacher.email_name,
+    set_recipients
+    mail to: @recipients,
          cc: CONTACT_EMAIL,
          subject: email_template.subject
   end
@@ -37,8 +40,9 @@ class TeacherMailer < ApplicationMailer
   def form_submission(teacher)
     @teacher = teacher
     set_body
+    set_recipients
     if @teacher.not_reviewed?
-      mail to: CONTACT_EMAIL,
+      mail to: @recipients,
            subject: email_template.subject
     end
   end
@@ -60,7 +64,13 @@ class TeacherMailer < ApplicationMailer
     @email_template ||= EmailTemplate.find_by(title: action_name.titlecase)
   end
 
+  # renders the email body with the {{parameter}} things
   def set_body
     @body = Liquid::Template.parse(email_template.body).render(liquid_assigns).html_safe
+  end
+
+  # renders the list of recipients with the {{parameter}} things
+  def set_recipients
+    @recipients = Liquid::Template.parse(email_template.to).render(liquid_assigns).html_safe
   end
 end

--- a/app/mailers/teacher_mailer.rb
+++ b/app/mailers/teacher_mailer.rb
@@ -16,18 +16,18 @@ class TeacherMailer < ApplicationMailer
          subject: email_template.subject
   end
 
-  def deny_email(teacher, reason)
+  def deny_email(teacher, denial_reason)
     @teacher = teacher
-    @reason = reason
+    @denial_reason = denial_reason
     set_body
     mail to: @teacher.email_name,
          cc: CONTACT_EMAIL,
          subject: email_template.subject
   end
 
-  def request_info_email(teacher, reason)
+  def request_info_email(teacher, request_reason)
     @teacher = teacher
-    @reason = reason
+    @request_reason = request_reason
     set_body
     mail to: @teacher.email_name,
          cc: CONTACT_EMAIL,
@@ -48,7 +48,7 @@ class TeacherMailer < ApplicationMailer
     base_rules = {
       bjc_password: Rails.application.secrets[:bjc_password],
       piazza_password: Rails.application.secrets[:piazza_password],
-      reason: @reason
+      denial_reason: @denial_reason
     }
     base_rules.merge!(@teacher.email_attributes)
     base_rules.with_indifferent_access

--- a/app/models/email_template.rb
+++ b/app/models/email_template.rb
@@ -14,6 +14,7 @@
 #  required   :boolean          default(FALSE)
 #  subject    :string
 #  title      :string
+#  to         :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #
@@ -21,7 +22,8 @@ class EmailTemplate < ApplicationRecord
   validates :title,
             inclusion: TeacherMailer.instance_methods(false).map { |method| method.to_s.titlecase },
             if: -> { self.required? }
-  validates :body, presence: true
+  validates :body, presence: { message: "cannot be blank" }
+  validates :to, presence: { message: "cannot be blank" }
 
   before_destroy :prevent_deleting_required_emails
 

--- a/app/views/email_templates/_form.html.erb
+++ b/app/views/email_templates/_form.html.erb
@@ -1,7 +1,10 @@
+<%# This part of the page is the email template form %>
 <%= form_with(model: email_template, local: true) do |form| %>
   <div class="form">
     <label for="email_template_title"><h3>Title</h3></label>
     <%= form.text_field :title, class: "form-control", readonly: email_template.required? %>
+    <label for="email_template_to"><h3>To</h3></label>
+    <%= form.text_field :to, class: "form-control" %>
     <label for="email_template_subject"><h3>Subject</h3></label>
     <%= form.text_field :subject, class: "form-control" %>
     <label for="email_template_body"><h3>Body</h3></label>
@@ -12,7 +15,7 @@
     <%= form.submit "Submit", class: "btn btn-primary" %>
   </div>
 <% end %>
-
+<%# This renders the section on "Allowed Tags" %>
 <%= render 'liquid_fields' %>
 
 <script type="text/javascript">

--- a/app/views/email_templates/_liquid_fields.erb
+++ b/app/views/email_templates/_liquid_fields.erb
@@ -27,5 +27,9 @@
       <td><code>{{denial_reason}}</code></td>
       <td>(Only on denial emails.)</td>
     </tr>
+    <tr>
+      <td><code>{{request_reason}}</code></td>
+      <td>(Only on request emails.)</td>
+    </tr>
   </tbody>
 </table>

--- a/app/views/email_templates/_liquid_fields.erb
+++ b/app/views/email_templates/_liquid_fields.erb
@@ -24,7 +24,7 @@
       <td>(The current piazza sign up password)</td>
     </tr>
     <tr>
-      <td><code>{{reason}}</code></td>
+      <td><code>{{denial_reason}}</code></td>
       <td>(Only on denial emails.)</td>
     </tr>
   </tbody>

--- a/app/views/main/_deny_modal.html.erb
+++ b/app/views/main/_deny_modal.html.erb
@@ -5,23 +5,25 @@
         <h4 class="modal-title"></h4>
         <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
       </div>
+      <!-- default action is deny, but it can be dynamically changed. Check the js at the bottom of this file -->
       <%= form_tag deny_teacher_path(0), method: :post, class: "form-horizontal" do %>
         <div class="modal-body">
-            <%= label_tag 'denial_reason', 'Reason', class: 'control-label' %>
-            <%= text_field_tag :denial_reason, params[:denial_reason], class: "form-control" %>
-            <!-- <div class="form-group">
-              <label for="reason-select">Reason for Denial (Select)</label>
-              <select id="reason-select" name="reason-select" class="form-control">
-                <option value="">Select a reason</option>
-                <option value="Incomplete Application">Incomplete Application</option>
-                <option value="Insufficient Experience">Insufficient Experience</option>
-                <option value="Unfavorable References">Unfavorable References</option>
-              </select>
-            </div> -->
-            <div class="form-check">
-              <%= check_box_tag :skip_email, 'skip_email', false, class: 'form-check-input' %>
-              <%= label_tag 'skip_email', 'Skip email notifcation?', class: 'form-check-label' %>
-            </div>
+          <%= hidden_field_tag :action_type, '', class: "form-control action-type" %>
+          <%= label_tag 'action_reason', 'Reason', class: 'control-label' %>
+          <%= text_field_tag :action_reason_placeholder, '', class: "form-control action-reason", id: "action_reason" %>
+          <!-- <div class="form-group">
+            <label for="reason-select">Reason for Denial (Select)</label>
+            <select id="reason-select" name="reason-select" class="form-control">
+              <option value="">Select a reason</option>
+              <option value="Incomplete Application">Incomplete Application</option>
+              <option value="Insufficient Experience">Insufficient Experience</option>
+              <option value="Unfavorable References">Unfavorable References</option>
+            </select>
+          </div> -->
+          <div class="form-check">
+            <%= check_box_tag :skip_email, 'skip_email', false, class: 'form-check-input' %>
+            <%= label_tag 'skip_email', 'Skip email notifcation?', class: 'form-check-label' %>
+          </div>
         </div>
         <div class="modal-footer">
           <button type="button" class="btn btn-danger" data-dismiss="modal">Cancel</button>
@@ -33,31 +35,43 @@
 </div>
 
 <script type="text/javascript">
-  let modal = $('.js-denialModal');
-  modal.on('shown.bs.modal', function (event) {
-    let button = $(event.relatedTarget);
-    let teacherId = button.data('teacher-id');
-    let teacherName = button.data('teacher-name');
-    let newAction = null;
-    let newTitle = null;
-    switch(button.data('modal-type')) {
-      case "deny":
-        newAction = `/teachers/${teacherId}/deny`;
-        newTitle = 'Deny ' + teacherName;
-        break;
-      case "request_info":
-        newAction = `/teachers/${teacherId}/request_info`;
-        newTitle = 'Request Info from ' + teacherName;
-        break;
-      default:
-        newAction = `/teachers/${teacherId}/deny`;
-        newTitle = 'Deny ' + teacherName;
-    }
-    modal.find('.form-horizontal').attr('action', newAction);
-    modal.find('.modal-title').text(newTitle);
-  });
-  modal.on('hidden.bs.modal', function () {
-    $('input[name="denial_reason"]').val('');
-    modal.find('.modal-title').text('');
-  });
+    let modal = $('.js-denialModal');
+    modal.on('shown.bs.modal', function (event) {
+        let button = $(event.relatedTarget); // Button that triggered the modal
+        let teacherId = button.data('teacher-id');
+        let teacherName = button.data('teacher-name');
+        let actionType = button.data('modal-type'); // Action type, e.g., "deny", "request_info"
+        let newAction, newTitle, inputName;
+
+        // Determine the action and title based on the button clicked
+        switch(actionType) {
+            case "deny":
+                newAction = `/teachers/${teacherId}/deny`;
+                newTitle = 'Deny ' + teacherName;
+                inputName = 'denial_reason'; // The dynamic part for the input's name attribute
+                break;
+            case "request_info":
+                newAction = `/teachers/${teacherId}/request_info`;
+                newTitle = 'Request Info from ' + teacherName;
+                inputName = 'request_reason'; // Change accordingly
+                break;
+            default:
+                newAction = `/teachers/${teacherId}/deny`;
+                newTitle = 'Deny ' + teacherName;
+                inputName = 'denial_reason'; // Fallback option
+        }
+
+        // Update the form's action and the modal's title
+        modal.find('.form-horizontal').attr('action', newAction);
+        modal.find('.modal-title').text(newTitle);
+
+        // Dynamically change the name attribute of the input field
+        modal.find('#action_reason').attr('name', inputName);
+    });
+
+    // Reset the input field when the modal is closed
+    modal.on('hidden.bs.modal', function () {
+        modal.find('#action_reason').val('').attr('name', 'action_reason_placeholder');
+        modal.find('.modal-title').text('');
+    });
 </script>

--- a/app/views/main/_deny_modal.html.erb
+++ b/app/views/main/_deny_modal.html.erb
@@ -7,8 +7,8 @@
       </div>
       <%= form_tag deny_teacher_path(0), method: :post, class: "form-horizontal" do %>
         <div class="modal-body">
-            <%= label_tag 'reason', 'Reason', class: 'control-label' %>
-            <%= text_field_tag :reason, params[:reason], class: "form-control" %>
+            <%= label_tag 'denial_reason', 'Reason', class: 'control-label' %>
+            <%= text_field_tag :denial_reason, params[:denial_reason], class: "form-control" %>
             <!-- <div class="form-group">
               <label for="reason-select">Reason for Denial (Select)</label>
               <select id="reason-select" name="reason-select" class="form-control">
@@ -57,7 +57,7 @@
     modal.find('.modal-title').text(newTitle);
   });
   modal.on('hidden.bs.modal', function () {
-    $('input[name="reason"]').val('');
+    $('input[name="denial_reason"]').val('');
     modal.find('.modal-title').text('');
   });
 </script>

--- a/app/views/main/dashboard.html.erb
+++ b/app/views/main/dashboard.html.erb
@@ -1,44 +1,44 @@
 <% provide(:title, "BJC Teacher Dashboard") %>
 <div class="requests-dashboard">
   <h2>New Requests</h2>
-    <table class="table js-dataTable">
-      <thead class="thead-dark">
-        <tr>
-          <%= render 'teachers/table_headers' %>
-          <th scope="col">Actions</th>
-        </tr>
-      </thead>
-      <tbody>
-        <% @unreviewed_teachers.each do |teacher| %>
-        <tr>
-          <%= render 'teachers/teacher', teacher: teacher %>
-          <td>
-            <div class="btn-group" role="group" aria-label="Validate or Remove Teacher">
-              <%= button_to("✔️", validate_teacher_path(teacher.id),
-                 class: 'btn-group btn btn-outline-success', type: 'button') %>
-              <!-- <span>
+  <table class="table js-dataTable">
+    <thead class="thead-dark">
+    <tr>
+      <%= render 'teachers/table_headers' %>
+      <th scope="col">Actions</th>
+    </tr>
+    </thead>
+    <tbody>
+    <% @unreviewed_teachers.each do |teacher| %>
+      <tr>
+        <%= render 'teachers/teacher', teacher: teacher %>
+        <td>
+          <div class="btn-group" role="group" aria-label="Validate or Remove Teacher">
+            <%= button_to("✔️", validate_teacher_path(teacher.id),
+                          class: 'btn-group btn btn-outline-success', type: 'button') %>
+            <span>
                 <button class="btn btn-outline-warning" type="button" data-toggle="modal" data-target=".js-denialModal"
-                  data-modal-type="request_info" data-teacher-id="<%= teacher.id %>" data-teacher-name="<%= teacher.full_name %>">
+                        data-modal-type="request_info" data-teacher-id="<%= teacher.id %>" data-teacher-name="<%= teacher.full_name %>">
                   ❓
                 </button>
-              </span> -->
-              <span>
+              </span>
+            <span>
                 <button class="btn btn-outline-danger" type="button" data-toggle="modal" data-target=".js-denialModal"
-                  data-modal-type="deny" data-teacher-id="<%= teacher.id %>" data-teacher-name="<%= teacher.full_name %>">
+                        data-modal-type="deny" data-teacher-id="<%= teacher.id %>" data-teacher-name="<%= teacher.full_name %>">
                   ❌
                 </button>
               </span>
-            </div>
-          </td>
-        </tr>
-        <% end %>
-      </tbody>
-    </table>
-    <% if @unreviewed_teachers.empty? %>
-      <div class="alert alert-success" role="alert">
-        <strong>No unreviewed forms!</strong>
-      </div>
+          </div>
+        </td>
+      </tr>
     <% end %>
+    </tbody>
+  </table>
+  <% if @unreviewed_teachers.empty? %>
+    <div class="alert alert-success" role="alert">
+      <strong>No unreviewed forms!</strong>
+    </div>
+  <% end %>
 </div>
 
 <%= render 'deny_modal' %>
@@ -52,65 +52,65 @@
     <h2>Course Statistics</h2>
     <table class="table">
       <thead class="thead-dark">
-        <tr>
+      <tr>
         <th scope="col"> Status </th>
         <th scope="col"> Count </th>
-        </tr>
+      </tr>
       </thead>
       <tbody>
-        <% @statuses.each do |key, value| %>
+      <% @statuses.each do |key, value| %>
         <tr>
           <td> <%= key.humanize.titlecase %> </td>
           <td> <%= value %> </td>
         </tr>
-        <% end %>
+      <% end %>
       </tbody>
-      </table>
+    </table>
   </div>
 
   <div class="col-6">
     <h2>School Statistics</h2>
     <table class="table">
       <thead class="thead-dark">
-        <tr>
+      <tr>
         <th scope="col">School</th>
         <th scope="col">Location</th>
         <th scope="col">Teachers</th>
-        </tr>
+      </tr>
       </thead>
       <tbody>
-        <% @schools.each do |school| %>
+      <% @schools.each do |school| %>
         <tr>
           <td><%= link_to(school.name, school_path(school)) %></td>
           <td><%= school.location %></td>
           <td><%= school.teachers_count %></td>
         </tr>
-        <% end %>
+      <% end %>
       </tbody>
     </table>
   </div>
 </div>
 
 <script>
-  let map;
-  function initMap() {
-    map = new google.maps.Map(document.getElementById('map'), {
-      center: {lat: 39.50, lng: -98.35},
-      zoom: 4
-    });
+    let map;
+    function initMap() {
+        map = new google.maps.Map(document.getElementById('map'), {
+            center: {lat: 39.50, lng: -98.35},
+            zoom: 4
+        });
 
-    let school_data = <%= School.all_maps_data.html_safe %>;
-    for (let school of school_data) {
-      let marker = new google.maps.Marker({
-        position: school.position,
-        map: map
-      });
-      let infoWindow = new google.maps.InfoWindow({ content: school.name });
-      marker.addListener('click', () => { infoWindow.open(map, marker) });
+        let school_data = <%= School.all_maps_data.html_safe %>;
+        for (let school of school_data) {
+            let marker = new google.maps.Marker({
+                position: school.position,
+                map: map
+            });
+            let infoWindow = new google.maps.InfoWindow({ content: school.name });
+            marker.addListener('click', () => { infoWindow.open(map, marker) });
+        }
     }
-  }
 </script>
 
 <script async defer
-  src="https://maps.googleapis.com/maps/api/js?key=AIzaSyA9YjQt1uyBo0rEKe7UWMeW9GUryKtaMVo&callback=initMap">
+        src="https://maps.googleapis.com/maps/api/js?key=AIzaSyA9YjQt1uyBo0rEKe7UWMeW9GUryKtaMVo&callback=initMap">
 </script>

--- a/db/migrate/20240218005604_add_to_field_to_email_template.rb
+++ b/db/migrate/20240218005604_add_to_field_to_email_template.rb
@@ -1,0 +1,8 @@
+class AddToFieldToEmailTemplate < ActiveRecord::Migration[6.1]
+  def change
+    add_column :email_templates, :to, :string
+    #below is the default prepopulated 'to' field value,
+    to_field = "{{teacher_email}}, {{teacher_personal_email}}"
+    EmailTemplate.update_all(to: to_field)
+  end
+end

--- a/db/migrate/20240220192015_change_to_field_for_form_submission.rb
+++ b/db/migrate/20240220192015_change_to_field_for_form_submission.rb
@@ -1,0 +1,5 @@
+class ChangeToFieldForFormSubmission < ActiveRecord::Migration[6.1]
+  def change
+    EmailTemplate.find_by(path: "teacher_mailer/form_submission").update(to: "lmock@berkeley.edu, contact@bjc.berkeley.edu")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_09_05_181019) do
+ActiveRecord::Schema.define(version: 2024_02_20_192015) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -65,6 +65,7 @@ ActiveRecord::Schema.define(version: 2023_09_05_181019) do
     t.string "title"
     t.string "subject"
     t.boolean "required", default: false
+    t.string "to"
   end
 
   create_table "pages", force: :cascade do |t|

--- a/db/seed_data.rb
+++ b/db/seed_data.rb
@@ -27,7 +27,7 @@ module SeedData
 
   @basic_email_with_reason = <<-DENY_EMAIL
     <p>
-      {{ reason | strip_tags }}
+      {{ denial_reason | strip_tags }}
     </p>
   DENY_EMAIL
 
@@ -38,7 +38,7 @@ module SeedData
     <p>[Your Name]</p>
     <p>Below, you can find the reason as to why it was rejected </p>
     <p>
-      {{ reason | strip_tags}}
+      {{ denial_reason | strip_tags}}
     </p>
   DENY_EMAIL1
 

--- a/db/seed_data.rb
+++ b/db/seed_data.rb
@@ -82,9 +82,12 @@ module SeedData
   REQUEST_INFO_EMAIL
 
 
+  @default_to_field = "{{teacher_email}}, {{teacher_personal_email}}"
+
   def self.emails
     [
       {
+        to: @default_to_field,
         body: @welcome_email,
         path: "teacher_mailer/welcome_email",
         locale: nil,
@@ -96,6 +99,7 @@ module SeedData
         subject: "Welcome to The Beauty and Joy of Computing!"
       },
       {
+        to: "lmock@berkeley.edu, contact@bjc.berkeley.edu",
         body: @form_submission,
         path: "teacher_mailer/form_submission",
         locale: nil,
@@ -107,6 +111,7 @@ module SeedData
         subject: "Form Submission"
       },
       {
+        to: @default_to_field,
         body: @deny_email,
         path: "teacher_mailer/deny_email",
         locale: nil,
@@ -119,6 +124,7 @@ module SeedData
       },
       {
         body: @request_info_email,
+        to: @default_to_field,
         path: "teacher_mailer/request_info_email",
         locale: nil,
         handler: "liquid",

--- a/db/seed_data.rb
+++ b/db/seed_data.rb
@@ -59,6 +59,29 @@ module SeedData
 
   DENY_EMAIL3
 
+  @request_info_email = <<-REQUEST_INFO_EMAIL
+    <p>Dear {{teacher_first_name}},</p>
+
+    <p>We hope this message finds you well. We're writing to you regarding your ongoing application with BJC. As part of our review process, we've identified that some additional information is required to move forward.</p>
+
+    <p><strong>Required Information:</strong><br>
+    We kindly ask you to provide the following details to complete your application:</p>
+    <p>{{ request_reason | strip_tags }}</p>
+
+    <p>To submit the requested information, please follow these steps:</p>
+    <ol>
+      <li>Log into your BJC account using your registered email and password.</li>
+      <li>Locate your current application and update the information.</li>
+      <li>Fill in the necessary details in the provided fields and submit the update.</li>
+    </ol>
+
+    <p>Thank you for your attention to this matter. We look forward to receiving the additional information and advancing your application process.</p>
+
+    <p>Warm regards,</p>
+    <p>[Your Name]</p>
+  REQUEST_INFO_EMAIL
+
+
   def self.emails
     [
       {
@@ -95,7 +118,7 @@ module SeedData
         subject: "Deny Email"
       },
       {
-        body: @basic_email_with_reason,
+        body: @request_info_email,
         path: "teacher_mailer/request_info_email",
         locale: nil,
         handler: "liquid",

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,7 +2,8 @@
 
 require_relative "seed_data"
 
-SeedData.emails.each { |email| EmailTemplate.find_or_create_by(email) }
+EmailTemplate.delete_all
+SeedData.emails.each { |email| EmailTemplate.create!(email) }
 
 SeedData.create_schools
 

--- a/features/admin.feature
+++ b/features/admin.feature
@@ -4,34 +4,34 @@ Feature: basic admin functionality
   So that I can see how many people are teaching BJC
   I can login in an see the dashboard
 
-Background: Has an Admin in DB
-  Given the following teachers exist:
-  | first_name | last_name | admin | email                        |
-  | Joseph     | Mamoa     | true  | testadminuser@berkeley.edu   |
+  Background: Has an Admin in DB
+    Given the following teachers exist:
+      | first_name | last_name | admin | email                        |
+      | Joseph     | Mamoa     | true  | testadminuser@berkeley.edu   |
 
-Scenario: Logging in as an admin
-  Given I am on the BJC home page
-  Given I have an admin email
-  And I follow "Log In"
-  Then I can log in with Google
-  And I should see "BJC Teacher Dashboard"
+  Scenario: Logging in as an admin
+    Given I am on the BJC home page
+    Given I have an admin email
+    And I follow "Log In"
+    Then I can log in with Google
+    And I should see "BJC Teacher Dashboard"
 
-Scenario: Logging out as an admin
-  Given I am on the BJC home page
-  Given I have an admin email
-  And I follow "Log In"
-  Then I can log in with Google
-  And I follow "Logout"
-  Then I should see "Request Access to BJC Teacher Materials"
-  Then I should see "Log In"
+  Scenario: Logging out as an admin
+    Given I am on the BJC home page
+    Given I have an admin email
+    And I follow "Log In"
+    Then I can log in with Google
+    And I follow "Logout"
+    Then I should see "Request Access to BJC Teacher Materials"
+    Then I should see "Log In"
 
-Scenario: Viewing Teachers as an admin
-  Given I am on the BJC home page
-  Given I have an admin email
-  And I follow "Log In"
-  Then I can log in with Google
-  When I go to the teachers page
-  Then I should see "BJC Teachers"
+  Scenario: Viewing Teachers as an admin
+    Given I am on the BJC home page
+    Given I have an admin email
+    And I follow "Log In"
+    Then I can log in with Google
+    When I go to the teachers page
+    Then I should see "BJC Teachers"
 
 # TODO: Add steps to check basic dashboard functions
 # A search field should be visible on the index pages
@@ -39,198 +39,221 @@ Scenario: Viewing Teachers as an admin
 
 # TODO: Checks for validation and deny belong here.
 
-Scenario: Logging in with non-admin, unregistered Google Account should fail
-  Given I have a non-admin, unregistered Google email
-  Given I am on the BJC home page
-  And I follow "Log In"
-  Then I can log in with Google
-  And I should see "Please submit a new request."
+  Scenario: Logging in with non-admin, unregistered Google Account should fail
+    Given I have a non-admin, unregistered Google email
+    Given I am on the BJC home page
+    And I follow "Log In"
+    Then I can log in with Google
+    And I should see "Please submit a new request."
 
-Scenario: Logging in with non-admin, unregistered Microsoft Account should fail
-  Given I have a non-admin, unregistered Microsoft email
-  Given I am on the BJC home page
-  And I follow "Log In"
-  Then I can log in with Microsoft
-  And I should see "Please submit a new request."
+  Scenario: Logging in with non-admin, unregistered Microsoft Account should fail
+    Given I have a non-admin, unregistered Microsoft email
+    Given I am on the BJC home page
+    And I follow "Log In"
+    Then I can log in with Microsoft
+    And I should see "Please submit a new request."
 
-Scenario: Logging in with non-admin, unregistered Snap Account should fail
-  Given I have a non-admin, unregistered Snap email
-  Given I am on the BJC home page
-  And I follow "Log In"
-  Then I can log in with Snap
-  And I should see "Please submit a new request."
+  Scenario: Logging in with non-admin, unregistered Snap Account should fail
+    Given I have a non-admin, unregistered Snap email
+    Given I am on the BJC home page
+    And I follow "Log In"
+    Then I can log in with Snap
+    And I should see "Please submit a new request."
 
-Scenario: Logging in with non-admin, unregistered Clever Account should fail
-  Given I have a non-admin, unregistered Clever email
-  Given I am on the BJC home page
-  And I follow "Log In"
-  Then I can log in with Clever
-  And I should see "Please submit a new request."
+  Scenario: Logging in with non-admin, unregistered Clever Account should fail
+    Given I have a non-admin, unregistered Clever email
+    Given I am on the BJC home page
+    And I follow "Log In"
+    Then I can log in with Clever
+    And I should see "Please submit a new request."
 
-Scenario: Non-admin, unregistered user should not be able to see admin-only pages
-  Given I have a non-admin, unregistered Google email
-  Given I am on the BJC home page
-  When  I go to the dashboard page
-  Then  I should see "Only admins can access this page"
-  And   I should be on the new teachers page
+  Scenario: Non-admin, unregistered user should not be able to see admin-only pages
+    Given I have a non-admin, unregistered Google email
+    Given I am on the BJC home page
+    When  I go to the dashboard page
+    Then  I should see "Only admins can access this page"
+    And   I should be on the new teachers page
 
-Scenario: Edit teacher info as an admin
-  Given the following schools exist:
-  |       name      |     city     |  state  |            website            |  grade_level  |  school_type  |
-  |   UC Berkeley   |   Berkeley   |   CA    |   https://www.berkeley.edu    |  university   |     public    |
-  Given the following teachers exist:
-  | first_name | last_name | admin | email                    | school      | snap   |
-  | Joseph     | Mamoa     | false | testteacher@berkeley.edu | UC Berkeley | alonzo |
-  Given I am on the BJC home page
-  Given I have an admin email
-  And   I follow "Log In"
-  Then  I can log in with Google
-  When  I go to the teachers page
-  When  I go to the edit page for Joseph Mamoa
-  Then  I should see "Joseph"
-  And   I enter my "First Name" as "Joe"
-  And   I set my status as "Other - Please specify below."
-  And   I set my education level target as "College"
-  And   I press "Update"
-  Then I see a confirmation "Saved"
+  Scenario: Edit teacher info as an admin
+    Given the following schools exist:
+      |       name      |     city     |  state  |            website            |  grade_level  |  school_type  |
+      |   UC Berkeley   |   Berkeley   |   CA    |   https://www.berkeley.edu    |  university   |     public    |
+    Given the following teachers exist:
+      | first_name | last_name | admin | email                    | school      | snap   |
+      | Joseph     | Mamoa     | false | testteacher@berkeley.edu | UC Berkeley | alonzo |
+    Given I am on the BJC home page
+    Given I have an admin email
+    And   I follow "Log In"
+    Then  I can log in with Google
+    When  I go to the teachers page
+    When  I go to the edit page for Joseph Mamoa
+    Then  I should see "Joseph"
+    And   I enter my "First Name" as "Joe"
+    And   I set my status as "Other - Please specify below."
+    And   I set my education level target as "College"
+    And   I press "Update"
+    Then I see a confirmation "Saved"
 
-Scenario: Deny teacher as an admin
-  Given the following schools exist:
-  | name        | city     | state | website                  | grade_level | school_type |
-  | UC Berkeley | Berkeley | CA    | https://www.berkeley.edu | university  | public      |
-  Given the following teachers exist:
-  | first_name | last_name | admin | email                    | school      |
-  | Joseph     | Mamoa     | false | testteacher@berkeley.edu | UC Berkeley |
-  Given I am on the BJC home page
-  Given I have an admin email
-  When  I follow "Log In"
-  Then  I can log in with Google
-  And   I press "❌" within "#DataTables_Table_0 > tbody > tr:nth-child(1)"
-  Then  I should see "Reason"
-  And   I should see "Deny Joseph Mamoa"
-  And   I fill in "denial_reason" with "Test"
-  And   I press "Cancel"
-  And   I press "❌" within "#DataTables_Table_0 > tbody > tr:nth-child(1)"
-  Then  the "denial_reason" field should not contain "Test"
-  And   I fill in "denial_reason" with "Denial Reason"
-  And   I press "Submit"
-  Then  I can send a deny email
+  Scenario: Deny teacher as an admin
+    Given the following schools exist:
+      | name        | city     | state | website                  | grade_level | school_type |
+      | UC Berkeley | Berkeley | CA    | https://www.berkeley.edu | university  | public      |
+    Given the following teachers exist:
+      | first_name | last_name | admin | email                    | school      |
+      | Joseph     | Mamoa     | false | testteacher@berkeley.edu | UC Berkeley |
+    Given I am on the BJC home page
+    Given I have an admin email
+    When  I follow "Log In"
+    Then  I can log in with Google
+    And   I press "❌" within "#DataTables_Table_0 > tbody > tr:nth-child(1)"
+    Then  I should see "Reason"
+    And   I should see "Deny Joseph Mamoa"
+    And   I fill in "denial_reason" with "Test"
+    And   I press "Cancel"
+    And   I press "❌" within "#DataTables_Table_0 > tbody > tr:nth-child(1)"
+    Then  the "denial_reason" field should not contain "Test"
+    And   I fill in "denial_reason" with "Denial Reason"
+    And   I press "Submit"
+    Then  I can send a deny email
 
-Scenario: Not logged in should not have access to edit
-  Given the following schools exist:
-  | name        | city     | state | website                  | grade_level | school_type |
-  | UC Berkeley | Berkeley | CA    | https://www.berkeley.edu | university  | public      |
-  Given the following teachers exist:
-  | first_name | last_name | admin | email                    | school      |
-  | Joseph     | Mamoa     | false | testteacher@berkeley.edu | UC Berkeley |
-  When  I go to the edit page for Joseph Mamoa
-  Then  should see "You need to log in to access this."
+  Scenario: Not logged in should not have access to edit
+    Given the following schools exist:
+      | name        | city     | state | website                  | grade_level | school_type |
+      | UC Berkeley | Berkeley | CA    | https://www.berkeley.edu | university  | public      |
+    Given the following teachers exist:
+      | first_name | last_name | admin | email                    | school      |
+      | Joseph     | Mamoa     | false | testteacher@berkeley.edu | UC Berkeley |
+    When  I go to the edit page for Joseph Mamoa
+    Then  should see "You need to log in to access this."
 
-Scenario: Filter all teacher info as an admin
-  Given the following schools exist:
-  | name        | city     | state | website                  | grade_level | school_type |
-  | UC Berkeley | Berkeley | CA    | https://www.berkeley.edu | university  | public      |
-  Given the following teachers exist:
-  | first_name | last_name  | admin | email                     | school      | application_status |
-  | Victor     | Validateme | false | testteacher1@berkeley.edu | UC Berkeley |      Validated     |
-  | Danny      | Denyme     | false | testteacher2@berkeley.edu | UC Berkeley |       Denied       |
-  | Peter      | Pendme     | false | testteacher3@berkeley.edu | UC Berkeley |     Not Reviewed   |
-  Given I am on the BJC home page
-  Given I have an admin email
-  And   I follow "Log In"
-  Then  I can log in with Google
-  When  I go to the teachers page
-  And   I check "Not Reviewed"
-  And   I uncheck "Validated"
-  Then  I should see "Peter"
-  Then  I should not see "Victor"
-  Then  I should not see "Danny"
-  And   I check "Validated"
-  Then  I should see "Peter"
-  Then  I should see "Victor"
-  Then  I should not see "Danny"
+  Scenario: Filter all teacher info as an admin
+    Given the following schools exist:
+      | name        | city     | state | website                  | grade_level | school_type |
+      | UC Berkeley | Berkeley | CA    | https://www.berkeley.edu | university  | public      |
+    Given the following teachers exist:
+      | first_name | last_name  | admin | email                     | school      | application_status |
+      | Victor     | Validateme | false | testteacher1@berkeley.edu | UC Berkeley |      Validated     |
+      | Danny      | Denyme     | false | testteacher2@berkeley.edu | UC Berkeley |       Denied       |
+      | Peter      | Pendme     | false | testteacher3@berkeley.edu | UC Berkeley |     Not Reviewed   |
+    Given I am on the BJC home page
+    Given I have an admin email
+    And   I follow "Log In"
+    Then  I can log in with Google
+    When  I go to the teachers page
+    And   I check "Not Reviewed"
+    And   I uncheck "Validated"
+    Then  I should see "Peter"
+    Then  I should not see "Victor"
+    Then  I should not see "Danny"
+    And   I check "Validated"
+    Then  I should see "Peter"
+    Then  I should see "Victor"
+    Then  I should not see "Danny"
 
-Scenario: View teacher info as an admin
-  Given the following schools exist:
-  | name        | city     | state | website                  | grade_level | school_type |
-  | UC Berkeley | Berkeley | CA    | https://www.berkeley.edu | university  | public      |
-  Given the following teachers exist:
-  | first_name | last_name | admin | email                    | school      | snap   |
-  | Joseph     | Test     | false | testteacher@berkeley.edu | UC Berkeley | alonzo |
-  Given I am on the BJC home page
-  Given I have an admin email
-  And   I follow "Log In"
-  Then  I can log in with Google
-  When  I go to the teachers page
-  And   I uncheck "Validated"
-  When  I follow "Joseph Test"
-  Then  I should see "Joseph Test"
-  And   I should see "Edit Information"
-  And   I should see "School"
-  And   I should see "School Location"
-  And   I should see "Email"
-  And   I should see "Personal or Course Website"
+  Scenario: View teacher info as an admin
+    Given the following schools exist:
+      | name        | city     | state | website                  | grade_level | school_type |
+      | UC Berkeley | Berkeley | CA    | https://www.berkeley.edu | university  | public      |
+    Given the following teachers exist:
+      | first_name | last_name | admin | email                    | school      | snap   |
+      | Joseph     | Test     | false | testteacher@berkeley.edu | UC Berkeley | alonzo |
+    Given I am on the BJC home page
+    Given I have an admin email
+    And   I follow "Log In"
+    Then  I can log in with Google
+    When  I go to the teachers page
+    And   I uncheck "Validated"
+    When  I follow "Joseph Test"
+    Then  I should see "Joseph Test"
+    And   I should see "Edit Information"
+    And   I should see "School"
+    And   I should see "School Location"
+    And   I should see "Email"
+    And   I should see "Personal or Course Website"
 
-Scenario: Edit teacher info as an admin navigating from view only page to edit page
-  Given the following schools exist:
-  |       name      |     city     |  state  |            website            |  grade_level  |  school_type  |
-  |   UC Berkeley   |   Berkeley   |   CA    |   https://www.berkeley.edu    |  university   |     public    |
-  Given the following teachers exist:
-  | first_name | last_name | admin | email                    | school      | snap   |
-  | Joseph     | Mamoa New    | false | testteacher@berkeley.edu | UC Berkeley | alonzo |
-  Given I am on the BJC home page
-  Given I have an admin email
-  And   I follow "Log In"
-  Then  I can log in with Google
-  When  I go to the teachers page
-  And   I uncheck "Validated"
-  When  I follow "Joseph Mamoa New"
-  Then  I should see "Joseph Mamoa"
-  And   I should see "Edit Information"
-  And   I follow "Edit Information"
-  And   I should see "Joseph"
-  And   I enter my "First Name" as "Joe"
-  And   I set my status as "Other - Please specify below."
-  And   I set my education level target as "College"
-  And   I press "Update"
-  Then  I see a confirmation "Saved"
+  Scenario: Edit teacher info as an admin navigating from view only page to edit page
+    Given the following schools exist:
+      |       name      |     city     |  state  |            website            |  grade_level  |  school_type  |
+      |   UC Berkeley   |   Berkeley   |   CA    |   https://www.berkeley.edu    |  university   |     public    |
+    Given the following teachers exist:
+      | first_name | last_name | admin | email                    | school      | snap   |
+      | Joseph     | Mamoa New    | false | testteacher@berkeley.edu | UC Berkeley | alonzo |
+    Given I am on the BJC home page
+    Given I have an admin email
+    And   I follow "Log In"
+    Then  I can log in with Google
+    When  I go to the teachers page
+    And   I uncheck "Validated"
+    When  I follow "Joseph Mamoa New"
+    Then  I should see "Joseph Mamoa"
+    And   I should see "Edit Information"
+    And   I follow "Edit Information"
+    And   I should see "Joseph"
+    And   I enter my "First Name" as "Joe"
+    And   I set my status as "Other - Please specify below."
+    And   I set my education level target as "College"
+    And   I press "Update"
+    Then  I see a confirmation "Saved"
 
-Scenario: Should be able to resend welcome email
-  Given the following schools exist:
-  |       name      |     city     |  state  |            website            |  grade_level  |  school_type  |
-  |   UC Berkeley   |   Berkeley   |   CA    |   https://www.berkeley.edu    |  university   |     public    |
-  Given the following teachers exist:
-  | first_name | last_name | admin | email                    | school      | snap   | application_status |
-  | Joseph     | Mamoa     | false | testteacher@berkeley.edu | UC Berkeley | alonzo | validated |
-  Given I am on the BJC home page
-  Given I have an admin email
-  And   I follow "Log In"
-  Then  I can log in with Google
-  When  I go to the teachers page
-  When  I go to the edit page for Joseph Mamoa
-  Then I should see a button named "Resend Welcome Email"
+  Scenario: Should be able to resend welcome email
+    Given the following schools exist:
+      |       name      |     city     |  state  |            website            |  grade_level  |  school_type  |
+      |   UC Berkeley   |   Berkeley   |   CA    |   https://www.berkeley.edu    |  university   |     public    |
+    Given the following teachers exist:
+      | first_name | last_name | admin | email                    | school      | snap   | application_status |
+      | Joseph     | Mamoa     | false | testteacher@berkeley.edu | UC Berkeley | alonzo | validated |
+    Given I am on the BJC home page
+    Given I have an admin email
+    And   I follow "Log In"
+    Then  I can log in with Google
+    When  I go to the teachers page
+    When  I go to the edit page for Joseph Mamoa
+    Then I should see a button named "Resend Welcome Email"
 
   Scenario: Admin can access new teacher button at teacher index page
-  Given I am on the BJC home page
-  Given I have an admin email
-  And I follow "Log In"
-  Then I can log in with Google
-  And I should see "BJC Teacher Dashboard"
-  Given I follow "Teachers"
-  Then I should see "BJC Teachers"
-  And I press "New Teacher"
-  Then I should see "Request Access to BJC Teacher Materials"
+    Given I am on the BJC home page
+    Given I have an admin email
+    And I follow "Log In"
+    Then I can log in with Google
+    And I should see "BJC Teacher Dashboard"
+    Given I follow "Teachers"
+    Then I should see "BJC Teachers"
+    And I press "New Teacher"
+    Then I should see "Request Access to BJC Teacher Materials"
 
   Scenario: Admin can access new school button at teacher index page
-  Given I am on the BJC home page
-  Given I have an admin email
-  And I follow "Log In"
-  Then I can log in with Google
-  And I should see "BJC Teacher Dashboard"
-  Given I follow "Schools"
-  Then I should see "BJC Schools"
-  And I press "New School"
-  Then I should see "Add a School"
+    Given I am on the BJC home page
+    Given I have an admin email
+    And I follow "Log In"
+    Then I can log in with Google
+    And I should see "BJC Teacher Dashboard"
+    Given I follow "Schools"
+    Then I should see "BJC Schools"
+    And I press "New School"
+    Then I should see "Add a School"
+
+  Scenario: Request information from a teacher as an admin
+    Given the following schools exist:
+      | name        | city     | state | website                  | grade_level | school_type |
+      | UC Berkeley | Berkeley | CA    | https://www.berkeley.edu | university  | public      |
+    And the following teachers exist:
+      | first_name | last_name | admin | email                    | school      |
+      | Joseph     | Mamoa     | false | testteacher@berkeley.edu | UC Berkeley |
+    And I am on the BJC home page
+    And I have an admin email
+    When I follow "Log In"
+    Then I can log in with Google
+    And I press "❓" within "#DataTables_Table_0 > tbody > tr:nth-child(1)"
+    Then I should see "Reason"
+    And I should see "Request Info from Joseph Mamoa"
+    And I fill in "request_reason" with "Need more details on qualifications"
+    And I press "Cancel"
+    And I press "❓" within "#DataTables_Table_0 > tbody > tr:nth-child(1)"
+    Then the "request_reason" field should not contain "Need more details on qualifications"
+    And I fill in "request_reason" with "Complete your profile details"
+    And I press "Submit"
+    Then I can send a request info email
+
 
 # Scenario: Admin can import csv file. The loader should filter invalid record and create associate school.
 #  Given the following schools exist:

--- a/features/admin.feature
+++ b/features/admin.feature
@@ -108,11 +108,11 @@ Scenario: Deny teacher as an admin
   And   I press "❌" within "#DataTables_Table_0 > tbody > tr:nth-child(1)"
   Then  I should see "Reason"
   And   I should see "Deny Joseph Mamoa"
-  And   I fill in "reason" with "Test"
+  And   I fill in "denial_reason" with "Test"
   And   I press "Cancel"
   And   I press "❌" within "#DataTables_Table_0 > tbody > tr:nth-child(1)"
-  Then  the "reason" field should not contain "Test"
-  And   I fill in "reason" with "Denial Reason"
+  Then  the "denial_reason" field should not contain "Test"
+  And   I fill in "denial_reason" with "Denial Reason"
   And   I press "Submit"
   Then  I can send a deny email
 

--- a/features/email_template.feature
+++ b/features/email_template.feature
@@ -33,3 +33,33 @@ Scenario: Logging in as an admin should be able to edit email subject
     And I press "Submit"
     And I follow "Welcome Email"
     Then the "email_template_subject" field should contain "Test Subject"
+
+Scenario: Creating new email template with blank fields displays flash error
+    Given I am on the email templates index
+    And I press "New Email Templates"
+    When I press "Submit"
+    Then I should see "Failed to submit information: Body cannot be blank, To cannot be blank"
+
+Scenario: Creating and deleting new email template with valid fields succeeds
+    Given I am on the email templates index
+    And I press "New Email Templates"
+    When I fill in "email_template_title" with "Test Email"
+    And I fill in "email_template_subject" with "Test Subject"
+    And I fill in "email_template_to" with "{{teacher_email}}"
+    And I fill in TinyMCE email form with "This is the body of my test email"
+    And I press "Submit"
+    Then I should see "Created Test Email successfully"
+    When I follow the first "❌" link
+    And I accept the popup alert
+    Then I should be on the email templates index
+    And I should not see "Test Email"
+
+Scenario: Editing email template to have blank body or to field displays flash error
+    Given I am on the email templates index
+    And I follow "Welcome Email"
+    And I fill in "email_template_to" with ""
+    And I press "Submit"
+    Then I should see "Failed to save Welcome Email template: To cannot be blank"
+    When I fill in TinyMCE email form with ""
+    And I press "Submit"
+    Then I should see "Failed to save Welcome Email template: Body cannot be blank"

--- a/features/step_definitions/admin_steps.rb
+++ b/features/step_definitions/admin_steps.rb
@@ -12,32 +12,32 @@ LOGIN_SERVICE = {
 # Returns a OAuth2 token associated with email "testadminuser@berkeley.edu"
 Given(/I have an admin email/) do
   OmniAuth.config.mock_auth[:google_oauth2] = OmniAuth::AuthHash.new({
-    provider: "google_oauth2",
-    uid: "123545",
-    info: {
-      name: "Admin User",
-      first_name: "Admin",
-      last_name: "User",
-      email: "testadminuser@berkeley.edu",
-      school: "UC Berkeley",
-    }
-  })
+                                                                       provider: "google_oauth2",
+                                                                       uid: "123545",
+                                                                       info: {
+                                                                         name: "Admin User",
+                                                                         first_name: "Admin",
+                                                                         last_name: "User",
+                                                                         email: "testadminuser@berkeley.edu",
+                                                                         school: "UC Berkeley",
+                                                                       }
+                                                                     })
 end
 
 # Returns a OAuth2 token associated with email "randomemail@gmail.com"
 Given(/I have a non-admin, unregistered (.*) email/) do |login|
   service = LOGIN_SERVICE[login]
   OmniAuth.config.mock_auth[service] = OmniAuth::AuthHash.new({
-    provider: service,
-    uid: "123545",
-    info: {
-      name: "Random User",
-      first_name: "Random",
-      last_name: "User",
-      email: "randomemail@berkeley.edu",
-      school: "UC Berkeley",
-    }
-  })
+                                                                provider: service,
+                                                                uid: "123545",
+                                                                info: {
+                                                                  name: "Random User",
+                                                                  first_name: "Random",
+                                                                  last_name: "User",
+                                                                  email: "randomemail@berkeley.edu",
+                                                                  school: "UC Berkeley",
+                                                                }
+                                                              })
 end
 
 # A wrapper around the omniauth link.
@@ -64,7 +64,7 @@ Then(/I can send a request info email/) do
   last_email = ActionMailer::Base.deliveries.last
   last_email.to[0].should eq "testteacher@berkeley.edu"
   last_email.subject.should eq "Request Info Email"
-  last_email.body.encoded.should include "Request Info Reason"
+  last_email.body.encoded.should include "We kindly ask you to provide the following details to complete your application:"
 end
 
 Then(/I attach the csv "([^"]*)"$/) do |path|

--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -60,6 +60,18 @@ When(/^(?:|I )fill in TinyMCE email form with "([^"]*)"$/) do |value|
   page.execute_script('$(tinymce.editors[0].setContent("' + value + '"))')
 end
 
+When(/^(?:|I )follow the first "([^"]*)" link$/) do |link_text|
+  first("a", text: link_text).click
+end
+
+When(/^(?:|I )press the first "([^"]*)" button$/) do |button_text|
+  first("button", text: button_text).click
+end
+
+Then(/^(?:|I )accept the popup alert$/) do
+  page.driver.browser.switch_to.alert.accept
+end
+
 When(/^(?:|I )fill in "([^"]*)" for "([^"]*)"$/) do |value, field|
   fill_in(field, with: value)
 end

--- a/spec/controllers/email_templates_reseed_spec.rb
+++ b/spec/controllers/email_templates_reseed_spec.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# This test suite verifies the reseeding behavior of EmailTemplate models to ensure
+# that email templates are correctly handled (i.e., updated or removed) without duplication
+# upon reseeding the database with new seed data. It tests the initial seeding, updates to
+# templates, and the removal of templates that are no longer present in the seed data.
+RSpec.describe "EmailTemplate Reseed Behavior", type: :model do
+  # Define email content for initial seeding and subsequent updates. These blocks
+  # provide a flexible way to manage test data, allowing us to simulate changes in seed data
+  # across different test scenarios.
+  let(:form_submission_old) do
+    <<-FORM_SUBMISSION
+      <p>Submitted Information:</p>
+      <p>I am the original content of the form submission email.</p>
+    FORM_SUBMISSION
+  end
+
+  let(:request_info_email_old) do
+    <<-REQUEST_INFO_EMAIL
+      <p>Dear {{teacher_first_name}},</p>
+      <p>I am the original content of the request info email.</p>
+    REQUEST_INFO_EMAIL
+  end
+
+  let(:request_info_email_new) do
+    <<-REQUEST_INFO_EMAIL
+    <p>Dear {{teacher_first_name}},</p>
+    <p>I am NEW Template Content of the request info email.</p>
+    REQUEST_INFO_EMAIL
+  end
+
+  # Setup phase: Mocks the SeedData.emails call to return predetermined email content.
+  # This mimics the initial seeding process with specific email templates before each test.
+  # The `load Rails.root.join("db/seeds.rb")` line simulates the seeding action.
+  before do
+    allow(SeedData).to receive(:emails).and_return(
+      [
+        {
+          to: "lmock@berkeley.edu, contact@bjc.berkeley.edu",
+          body: form_submission_old,
+          path: "teacher_mailer/form_submission",
+          locale: nil,
+          handler: "liquid",
+          partial: false,
+          format: "html",
+          title: "Form Submission",
+          required: true,
+          subject: "Form Submission"
+        },
+        {
+          body: request_info_email_old,
+          to: "{{teacher_email}}, {{teacher_personal_email}}",
+          path: "teacher_mailer/request_info_email",
+          locale: nil,
+          handler: "liquid",
+          partial: false,
+          format: "html",
+          title: "Request Info Email",
+          required: true,
+          subject: "Request Info Email"
+        }
+      ])
+    # Initial seed with original data
+    load Rails.root.join("db/seeds.rb")
+  end
+
+  # This test verifies the entire reseed process by first checking the state after initial seeding,
+  # then mocking updated seed data, reseeding, and finally asserting the expected outcomes.
+  # It checks for the correct handling of both updated and removed email templates.
+  it "correctly handles email templates on reseed without duplication" do
+    # Verify original content
+    expect(EmailTemplate.count).to eq(2)
+    request_info_email = EmailTemplate.find_by(title: "Request Info Email")
+    expect(request_info_email.title).to eq("Request Info Email")
+    expect(request_info_email.body).to include("I am the original content of the request info email")
+
+    form_submission_email = EmailTemplate.find_by(title: "Form Submission")
+    expect(form_submission_email.title).to eq("Form Submission")
+    expect(form_submission_email.body).to include("I am the original content of the form submission email")
+
+    # Simulate an update to the seed data by changing the content of one email template
+    # and removing another. This prepares for the reseed to test how the application handles
+    # updated and removed templates.
+    allow(SeedData).to receive(:emails).and_return(
+      [
+        {
+          body: request_info_email_new,
+          to: "{{teacher_email}}, {{teacher_personal_email}}",
+          path: "teacher_mailer/request_info_email",
+          locale: nil,
+          handler: "liquid",
+          partial: false,
+          format: "html",
+          title: "Request Info Email",
+          required: true,
+          subject: "Request Info Email"
+        }
+      ])
+    load Rails.root.join("db/seeds.rb")
+
+    # Final assertions to verify that after reseeding, the email templates in the database
+    # reflect the updated seed data: updated content is present, and removed templates are absent.
+    expect(EmailTemplate.count).to eq(1)
+
+    request_info_email = EmailTemplate.find_by(title: "Request Info Email")
+    expect(request_info_email.title).to eq("Request Info Email")
+    expect(request_info_email.body).to include("NEW Template Content of the request info email")
+
+    expect(EmailTemplate.find_by(title: "Form Submission")).to be_nil
+  end
+end

--- a/spec/controllers/teachers_controller_spec.rb
+++ b/spec/controllers/teachers_controller_spec.rb
@@ -188,6 +188,7 @@ RSpec.describe TeachersController, type: :controller do
     it "succeeds when teacher is validated, sets success" do
       ApplicationController.any_instance.stub(:current_user).and_return(Teacher.find_by(first_name: "Validated"))
       validated_teacher = Teacher.find_by(first_name: "Validated")
+      request.env["HTTP_REFERER"] = edit_teacher_path(validated_teacher.id)
       post :resend_welcome_email, params: { id: validated_teacher.id }
       expect(flash[:success]).to eq("Welcome email resent successfully!")
       expect(response).to redirect_to(edit_teacher_path(validated_teacher.id))
@@ -196,10 +197,10 @@ RSpec.describe TeachersController, type: :controller do
     it "fails when teacher is not validated, sets alert" do
       ApplicationController.any_instance.stub(:current_user).and_return(Teacher.find_by(first_name: "Short"))
       nonvalidated_teacher = Teacher.find_by(first_name: "Short")
+      request.env["HTTP_REFERER"] = teacher_path(nonvalidated_teacher.id)
       post :resend_welcome_email, params: { id: nonvalidated_teacher.id }
-      expect(flash[:alert]).to eq("Error resending welcome email. \
-      Please ensure that your account has been validated by an administrator.")
-      expect(response).to redirect_to(edit_teacher_path(nonvalidated_teacher.id))
+      expect(flash[:alert]).to eq("Error resending welcome email. Please ensure that your account has been validated by an administrator.")
+      expect(response).to redirect_to(teacher_path(nonvalidated_teacher.id))
     end
   end
 end

--- a/spec/controllers/teachers_controller_spec.rb
+++ b/spec/controllers/teachers_controller_spec.rb
@@ -183,4 +183,23 @@ RSpec.describe TeachersController, type: :controller do
       expect(Teacher.find_by(email: "valid_example@valid_example.edu").not_reviewed?).to be true
     end
   end
+
+  context "flash a message after resend_welcome_email" do
+    it "succeeds when teacher is validated, sets success" do
+      ApplicationController.any_instance.stub(:current_user).and_return(Teacher.find_by(first_name: "Validated"))
+      validated_teacher = Teacher.find_by(first_name: "Validated")
+      post :resend_welcome_email, params: { id: validated_teacher.id }
+      expect(flash[:success]).to eq("Welcome email resent successfully!")
+      expect(response).to redirect_to(edit_teacher_path(validated_teacher.id))
+    end
+
+    it "fails when teacher is not validated, sets alert" do
+      ApplicationController.any_instance.stub(:current_user).and_return(Teacher.find_by(first_name: "Short"))
+      nonvalidated_teacher = Teacher.find_by(first_name: "Short")
+      post :resend_welcome_email, params: { id: nonvalidated_teacher.id }
+      expect(flash[:alert]).to eq("Error resending welcome email. \
+      Please ensure that your account has been validated by an administrator.")
+      expect(response).to redirect_to(edit_teacher_path(nonvalidated_teacher.id))
+    end
+  end
 end

--- a/spec/fixtures/teachers.yml
+++ b/spec/fixtures/teachers.yml
@@ -96,3 +96,16 @@ reimu:
   school: berkeley
   application_status: Info Needed
   education_level: -1
+
+barney:
+  id: 6
+  first_name: Barney
+  last_name: Dinosaur
+  snap: barney
+  email: 'barneydinosaur@gmail.com'
+  personal_email: 'bigpurpletrex@gmail.com'
+  status: 1
+  more_info: ''
+  application_status: Denied
+  school: berkeley
+  education_level: -1

--- a/spec/mailers/teacher_mailer_spec.rb
+++ b/spec/mailers/teacher_mailer_spec.rb
@@ -36,4 +36,17 @@ describe TeacherMailer do
     expect(email.to[0]).to eq("lmock@berkeley.edu")
     expect(email.body.encoded).to include("Short Long")
   end
+
+  it "Sends Request Info Email" do
+    teacher = teachers(:long)
+    email = TeacherMailer.request_info_email(teacher, "Request Reason")
+    email.deliver_now
+    expect(email.from[0]).to eq("contact@bjc.berkeley.edu")
+    expect(email.to[0]).to eq("short@long.com")
+    expect(email.subject).to eq("Request Info Email")
+    # Test appearance of first_name
+    expect(email.body.encoded).to include("Short")
+    expect(email.body.encoded).to include("Request Reason")
+    expect(email.body.encoded).to include("We're writing to you regarding your ongoing application with BJC.")
+  end
 end

--- a/spec/mailers/teacher_mailer_spec.rb
+++ b/spec/mailers/teacher_mailer_spec.rb
@@ -17,6 +17,17 @@ describe TeacherMailer do
      expect(email.body.encoded).to include("Hi Bob")
    end
 
+  it "Sends to Both School and Personal Email When Possible" do
+   teacher = teachers(:barney)
+   email = TeacherMailer.welcome_email(teacher)
+   email.deliver_now
+   expect(email.from[0]).to eq("contact@bjc.berkeley.edu")
+   expect(email.to[0]).to eq("barneydinosaur@gmail.com")
+   expect(email.to[1]).to eq("bigpurpletrex@gmail.com")
+   expect(email.subject).to eq("Welcome to The Beauty and Joy of Computing!")
+   expect(email.body.encoded).to include("Hi Barney")
+ end
+
 
   it "Sends Deny Email" do
     teacher = teachers(:long)


### PR DESCRIPTION
### [Pivotal Tracker Link][tracker]

<!-- Complete this section filling in the link to a tracker story. -->
[tracker]: https://www.pivotaltracker.com/story/show/187113121

## What this PR does:
<!-- Complete the following sentence: -->

This pull request ___fixes___ the issue of duplication and deletion of Email Templates upon reseeding the database with updated seed data.

### Include screenshots, videos, etc.
#### Previous Problem - Duplication of Email Templates after Reseeding Updated Email Templates
![Previous Problem](https://github.com/beautyjoy/BJC-Teacher-Tracker/assets/92573736/3091bd23-73fa-407a-a5d2-a98b2a8f9b2d)
#### After Fix
1. No Duplication of Email Templates after Reseeding Updated Email Templates.
2. It also considers the case to completely delete the email template and reseed it again, ensuring the database reflects the most current seed data without orphaned records.

#### Who authored this PR?
<!-- Tag the names of any other contributors -->
1. Perry (Jingchao) Zhong
2. Michael Tao

### How should this PR be tested?

- Ensure that the test suite covers scenarios for both updating existing email templates and removing obsolete templates from the database upon reseeding.
- Specifically, the tests should verify that after reseeding:
    1. Updated templates reflect the new changes without creating duplicate entries.
    2. Templates not included in the new seed data are properly removed from the database.

* **What do the specs/features test?**
  The specs test the reseeding process's ability to update and clean up email templates in the database accurately.
* **Are there edge cases to watch out for?**
  Not yet.

#### Are there any complications to deploying this?
Possible to have. Potential complications include the deletion of email template records from the database, aiming to prevent duplication and remove outdated templates. This can lead to data loss if users rely on templates not included in the seed data but present in the database, unaware of these changes.

### Checklist:

- [x] Tag someone for code review (either a coach / team member)
- [x] I have renamed the branch to match PivotTracker's suggested one (necessary for BlueJay) (e.g., `perry/187113121-fix-email-template-reseed-issue`). Any branch name will do as long as the story ID is there. You can use `git checkout -b [new-branch-name]`
