### PR TITLE
Iteration 2 - Add school location to teacher view

### DIFF
--- a/app/views/teachers/_teacher_info.html.erb
+++ b/app/views/teachers/_teacher_info.html.erb
@@ -99,6 +99,7 @@
     <div class="row mb-4">
       <div class="col-sm-3 font-weight-bold">School Location:</div>
       <div class="col-sm-9">
+        <%= teacher.school_location %>
       </div>
     </div>
     <div class="row">

--- a/features/admin.feature
+++ b/features/admin.feature
@@ -232,6 +232,7 @@ Feature: basic admin functionality
     And   I should see "Edit Information"
     And   I should see "School"
     And   I should see "School Location"
+    And   I should see "Berkeley, CA"
     And   I should see "Email"
     And   I should see "Personal or Course Website"
 


### PR DESCRIPTION
This feature just adds school location to the teacher view and modifies a test for the teacher view to make sure it displays the location. 

There are only two diffs that are related to this feature (the rest are from other features that haven't been merged into golden repo):
1. app/views/teachers/_teacher_info.html.erb: add school location into view
2. features/admin.feature: make sure we see "Berkeley, CA" in teacher view