### PR TITLE
Iteration 1 - Readd school merging

### DIFF
--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -10,6 +10,7 @@ class SchoolsController < ApplicationController
 
   def show
     @school = School.find(params[:id])
+    @all_schools_except_current = School.where.not(id: @school.id).order(:name)
   end
 
   def search

--- a/app/views/merge/school_preview.html.erb
+++ b/app/views/merge/school_preview.html.erb
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Merge <%= @from_school.name %> into <%= @into_school.name %></title>
+  <style>
+    .school-info {
+      display: flex;
+    }
+
+    .school-info .school {
+      flex: 1;
+    }
+
+    .school-info .school + .school {
+      margin-left: 20px;
+    }
+
+    .header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+
+    .title {
+      flex-grow: 1;
+    }
+
+    .button {
+      margin-left: 10px;
+    }
+
+    .btn-green {
+      background-color: green;
+    }
+
+    .btn-orange {
+      background-color: orange;
+    }
+  </style>
+</head>
+<body>
+  <div class="header">
+    <div class="title">
+      <%= content_tag :h1, "Preview Merge of #{@from_school.name} into #{@into_school.name}" %>
+    </div>
+    <div class="button">
+      <%= link_to "Switch Merge Order", preview_school_merge_path(from: @into_school.id, into: @from_school.id), method: :get, class: "btn btn-primary switch-merge-button btn-orange" %>
+    </div>
+    <div class="button">
+      <%= link_to "Confirm Merge", school_merge_path(from: @from_school.id, into: @into_school.id), method: :patch, class: "btn btn-primary confirm-merge-button btn-green" %>
+    </div>
+  </div>
+
+  <div class="school-info">
+    <%= tag.div class: 'school' do %>
+      <%= render 'schools/school_info', school: @from_school, display_deletion_warning_icon: true, render_edit: false, render_delete: false, render_smaller: true, is_show_page: false %>
+    <% end %>
+    <%= tag.div class: 'school' do %>
+      <%= render 'schools/school_info', school: @into_school, display_deletion_warning_icon: false, render_edit: false, render_delete: false, render_smaller: true, is_show_page: false %>
+    <% end %>
+    <%= tag.div class: 'school' do %>
+      <%= render 'schools/school_info', school: @result_school, display_deletion_warning_icon: false, render_edit: false, render_delete: false, render_smaller: true, is_show_page: false %>
+    <% end %>
+  </div>
+</body>
+</html>

--- a/app/views/schools/_school_info.html.erb
+++ b/app/views/schools/_school_info.html.erb
@@ -1,0 +1,91 @@
+<div class="card">
+  <div class="card-header d-flex justify-content-between align-items-center">
+    <h3><%= school.name %>
+      <% if display_deletion_warning_icon %>
+        <p style="font-size: smaller;">
+          ❌
+        </p>
+      <% end %>
+    </h3>
+    <div>
+      <% if is_show_page && @is_admin %>
+        <button id="school-merge-button" class="btn btn-warning mr-2">Merge</button>
+      <% end %>
+      <% if render_edit %>
+        <% button_class = render_smaller ? " btn-sm" : "" %>
+        <%= link_to "Edit", edit_school_path(school), class: "btn btn-primary mr-2" + button_class %>
+      <% end %>
+      <% if render_delete %>
+        <%= link_to("Delete", school_path(school), method: "delete",
+              class: "btn btn-danger" + (render_smaller ? " btn-sm" : ""),
+              data: { confirm: "Are you sure?" }) %>
+      <% end %>
+    </div>
+  </div>
+  <div class="card-body">
+    <% if @is_admin %>
+      <div class="row mb-4">
+        <div class="col-sm-3 font-weight-bold">School ID:</div>
+        <div class="col-sm-9">
+          <%= school.id %>
+        </div>
+      </div>
+    <% end %>
+    <div class="row mb-4">
+      <div class="col-sm-3 font-weight-bold">Name:</div>
+      <div class="col-sm-9">
+        <%= school.name %>
+      </div>
+    </div>
+    <div class="row mb-4">
+      <div class="col-sm-3 font-weight-bold">Location:</div>
+      <div class="col-sm-9">
+        <%= school.location %>
+      </div>
+    </div>
+    <div class="row mb-4">
+      <div class="col-sm-3 font-weight-bold">Website:</div>
+      <div class="col-sm-9">
+        <% if school.website.present? %>
+          <%= link_to(school.website, school.website) %>
+        <% end %>
+      </div>
+    </div>
+    <div class="row mb-4">
+      <div class="col-sm-3 font-weight-bold">Grade Level:</div>
+      <div class="col-sm-9">
+        <%= school.display_grade_level %>
+      </div>
+    </div>
+    <div class="row mb-4">
+      <div class="col-sm-3 font-weight-bold">School Type:</div>
+      <div class="col-sm-9">
+        <%= school.school_type %>
+      </div>
+    </div>
+    <div class="row mb-4">
+      <div class="col-sm-3 font-weight-bold">Tags:</div>
+      <div class="col-sm-9">
+        <%= school.tags.join(", ") if school.tags.present? %>
+      </div>
+    </div>
+    <div class="row mb-4">
+      <div class="col-sm-3 font-weight-bold">NCES ID:</div>
+      <div class="col-sm-9">
+        <%= school.nces_id %>
+      </div>
+    </div>
+    <div class="row mb-4">
+      <div class="col-sm-3 font-weight-bold">Number of Teachers:</div>
+      <div class="col-sm-9">
+        <%= school.teachers_count %>
+      </div>
+    </div>
+    <div class="row mb-4">
+      <div class="col-sm-3 font-weight-bold">Date Added:</div>
+      <div class="col-sm-9">
+        <%= school.created_at %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/schools/show.html.erb
+++ b/app/views/schools/show.html.erb
@@ -11,6 +11,9 @@
       <div class="col-sm-4 text-right">
         <%= link_to("Edit", edit_school_path(@school), class: "btn btn-primary") %>
         <%= link_to("Delete", school_path(@school), method: "delete", class: "btn btn-danger", data: {confirm: "Are you sure?"}) %>
+        <% if @is_admin %>
+          <button id="school-merge-button" class="btn btn-warning">Merge</button>
+        <% end %>
       </div>
     </div>
   </div>
@@ -85,3 +88,42 @@
     </div>
   </div>
 </div>
+
+<!-- School Merge Modal -->
+<div id="school-merge-modal" class="merge_modal">
+  <div class="merge_modal-content">
+    <h2>Choose A School To Merge Into</h2>
+    <span class="close">&times;</span>
+    <table class="table table-striped js-dataTable">
+      <thead class="thead-dark">
+        <tr>
+          <th>Name</th>
+          <th>Location</th>
+          <th>Grade Level</th>
+          <th>Teachers</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @all_schools_except_current.each do |school| %>
+          <tr>
+            <td>
+              <%= link_to school.name, preview_school_merge_path(from: @school.id, into: school.id), method: :get %>
+            </td>
+            <td><%= school.location %></td>
+            <td><%= school.display_grade_level %></td>
+            <td><%= school.teachers_count %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<script>
+  $(document).ready(function() {
+    let modal = $('#school-merge-modal');
+
+    $('#school-merge-button').click(() => modal.show());
+    $('.close').click(() => modal.hide());
+  });
+</script>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,4 +35,7 @@ Rails.application.routes.draw do
 
   get "merge/:from/:into/preview", to: "merge#preview", as: "preview_merge"
   patch "merge/:from/:into/execute", to: "merge#execute", as: "merge"
+
+  get "school_merge/:from/:into/preview", to: "merge#school_preview", as: "preview_school_merge"
+  patch "school_merge/:from/:into/execute", to: "merge#school_execute", as: "school_merge"
 end

--- a/features/admin.feature
+++ b/features/admin.feature
@@ -501,3 +501,114 @@ Feature: basic admin functionality
 #  Then I should see "Successfully created/updated 2 teachers"
 #  Then I should see "1 schools has been created"
 #  Then I should see "2 teachers has failed with following emails: [ steve.gao02112@gmail.com ] [ steve.fdso02112@gmail.com ]"
+
+  # ---------------------------------------------------------------------------
+  # School Merge
+  # ---------------------------------------------------------------------------
+
+  Scenario: Admin sees Merge button on school show page
+    Given the following schools exist:
+      | name        | country | city   | state | website                    | grade_level | school_type |
+      | Test School | US      | Irvine | CA    | https://www.testschool.edu | high_school | public      |
+      | Dupe School | US      | Irvine | CA    | https://www.dupeschool.edu | high_school | public      |
+    Given I am on the BJC home page
+    And I have an admin email
+    And I follow "Log In"
+    Then I can log in with Google
+    And I am on the schools page
+    And I follow "Test School"
+    Then I should see "Merge"
+
+  Scenario: Admin sees other schools listed in the merge modal
+    Given the following schools exist:
+      | name        | country | city   | state | website                    | grade_level | school_type |
+      | Test School | US      | Irvine | CA    | https://www.testschool.edu | high_school | public      |
+      | Dupe School | US      | Irvine | CA    | https://www.dupeschool.edu | high_school | public      |
+    Given I am on the BJC home page
+    And I have an admin email
+    And I follow "Log In"
+    Then I can log in with Google
+    And I am on the schools page
+    And I follow "Test School"
+    And I press "Merge"
+    Then I should see "Choose A School To Merge Into"
+    And I should see "Dupe School"
+
+  Scenario: Admin can preview a school merge
+    Given the following schools exist:
+      | name        | country | city   | state | website                    | grade_level | school_type |
+      | Test School | US      | Irvine | CA    | https://www.testschool.edu | high_school | public      |
+      | Dupe School | US      | Irvine | CA    | https://www.dupeschool.edu | high_school | public      |
+    Given I am on the BJC home page
+    And I have an admin email
+    And I follow "Log In"
+    Then I can log in with Google
+    And I am on the schools page
+    And I follow "Test School"
+    And I press "Merge"
+    And I follow "Dupe School"
+    Then I should see "Preview Merge of Test School into Dupe School"
+    And I should see "Switch Merge Order"
+    And I should see "Confirm Merge"
+
+  Scenario: Admin can complete a school merge
+    Given the following schools exist:
+      | name        | country | city   | state | website                    | grade_level | school_type |
+      | Test School | US      | Irvine | CA    | https://www.testschool.edu | high_school | public      |
+      | Dupe School | US      | Irvine | CA    | https://www.dupeschool.edu | high_school | public      |
+    And the following teachers exist:
+      | first_name | last_name | admin | primary_email        | school      |
+      | Teacher    | One       | false | teacher1@example.com | Dupe School |
+    Given I am on the BJC home page
+    And I have an admin email
+    And I follow "Log In"
+    Then I can log in with Google
+    And I am on the schools page
+    And I follow "Test School"
+    And I press "Merge"
+    And I follow "Dupe School"
+    And I follow "Confirm Merge"
+    Then I should see "Schools merged successfully."
+    And I should not see "Test School"
+
+  Scenario: School merge preserves non-blank fields and fills blank fields from from school
+    Given the following schools exist:
+      | name        | country | city   | state | website                    | grade_level | school_type | nces_id   |
+      | Test School | US      | Irvine | CA    | https://www.testschool.edu | high_school | public      | 111111111 |
+      | Dupe School | US      | Irvine | CA    | https://www.dupeschool.edu | high_school | public      |           |
+    Given I am on the BJC home page
+    And I have an admin email
+    And I follow "Log In"
+    Then I can log in with Google
+    And I am on the schools page
+    And I follow "Test School"
+    And I press "Merge"
+    And I follow "Dupe School"
+    And I follow "Confirm Merge"
+    Then I should see "Schools merged successfully."
+    And I follow "Dupe School"
+    And I follow "Edit"
+    Then the "NCES ID" field should contain "111111111"
+    And the "School Website" field should contain "dupeschool.edu"
+    And the "School Website" field should not contain "testschool.edu"
+
+  Scenario: Teachers are re-pointed to surviving school after merge
+    Given the following schools exist:
+      | name        | country | city   | state | website                    | grade_level | school_type |
+      | Test School | US      | Irvine | CA    | https://www.testschool.edu | high_school | public      |
+      | Dupe School | US      | Irvine | CA    | https://www.dupeschool.edu | high_school | public      |
+    And the following teachers exist:
+      | first_name | last_name | admin | primary_email        | school      |
+      | Teacher    | One       | false | teacher1@example.com | Test School |
+    Given I am on the BJC home page
+    And I have an admin email
+    And I follow "Log In"
+    Then I can log in with Google
+    And I am on the schools page
+    And I follow "Test School"
+    And I press "Merge"
+    And I follow "Dupe School"
+    And I follow "Confirm Merge"
+    Then I should see "Schools merged successfully."
+    And I follow "Dupe School"
+    Then I should see "Teacher One"

--- a/spec/controllers/merge_controller_spec.rb
+++ b/spec/controllers/merge_controller_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe MergeController, type: :request do
+  fixtures :all
+
+  let(:admin_teacher) { teachers(:admin) }
+  let(:from_school) { schools(:berkeley) }
+  let(:into_school) { schools(:stanfurd) }
+
+  context "for a non-admin" do
+    it "redirects preview to root" do
+      get preview_school_merge_path(from: from_school.id, into: into_school.id)
+      expect(response).to redirect_to(root_path)
+    end
+
+    it "redirects execute to root" do
+      patch school_merge_path(from: from_school.id, into: into_school.id)
+      expect(response).to redirect_to(root_path)
+    end
+  end
+
+  context "for an admin" do
+    before do
+      log_in(admin_teacher)
+    end
+
+    it "renders the preview page successfully" do
+      get preview_school_merge_path(from: from_school.id, into: into_school.id)
+      expect(response).to be_successful
+    end
+
+    it "executes the merge: destroys from_school and redirects" do
+      expect { patch school_merge_path(from: from_school.id, into: into_school.id) }
+        .to change { School.exists?(from_school.id) }.from(true).to(false)
+      expect(response).to redirect_to(schools_path)
+      expect(flash[:notice]).to eq("Schools merged successfully.")
+    end
+
+    it "re-points teachers from the deleted school to the surviving school" do
+      teacher = teachers(:bob) # belongs to berkeley (from_school)
+      patch school_merge_path(from: from_school.id, into: into_school.id)
+      expect(teacher.reload.school_id).to eq(into_school.id)
+    end
+
+    it "preserves the surviving school after merge" do
+      patch school_merge_path(from: from_school.id, into: into_school.id)
+      expect(School.exists?(into_school.id)).to be true
+    end
+  end
+end

--- a/spec/controllers/merge_controller_spec.rb
+++ b/spec/controllers/merge_controller_spec.rb
@@ -12,12 +12,12 @@ RSpec.describe MergeController, type: :request do
   context "for a non-admin" do
     it "redirects preview to root" do
       get preview_school_merge_path(from: from_school.id, into: into_school.id)
-      expect(response).to redirect_to(root_path)
+      expect(response).to redirect_to(login_path)
     end
 
     it "redirects execute to root" do
       patch school_merge_path(from: from_school.id, into: into_school.id)
-      expect(response).to redirect_to(root_path)
+      expect(response).to redirect_to(login_path)
     end
   end
 


### PR DESCRIPTION
This PR reverts another revert that I made since I messed up the git history by merging two features at once. A lot of the commits and file changes are from the "personal_website" feature that hasn't been merged into golden repo yet.

This pull request implements the feature for admins to manually merge two schools, similar to how they can merge two teachers.

Include screenshots, videos, etc.
<img width="3024" height="1656" alt="image" src="https://github.com/user-attachments/assets/c57c8e03-3dab-4c10-80d7-59ba411e6a3c" />
<img width="3024" height="1656" alt="image" src="https://github.com/user-attachments/assets/48606257-100c-459a-a3ad-da767e62f0a0" />

Who authored this PR?
Kien Huynh

How should this PR be tested?
Note: this PR may seem long but nearly all logic and views are copied over from the teacher merging feature.
Feature is deployed to Heroku to test. 