### PR TITLE
Iteration 2 - Showing other results available in different categories when filters are on

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem "rails", "6.1.7.7"
 # Production app server
 gem "puma", "~> 5"
 gem "pg", "~> 1.5"
+gem "pg_search"
 
 # Front-end Assets
 gem "webpacker"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -351,6 +351,9 @@ GEM
       racc
     path_expander (1.1.1)
     pg (1.5.3)
+    pg_search (2.3.7)
+      activerecord (>= 6.1)
+      activesupport (>= 6.1)
     pronto (0.11.1)
       gitlab (>= 4.4.0, < 5.0)
       httparty (>= 0.13.7, < 1.0)
@@ -592,6 +595,7 @@ DEPENDENCIES
   omniauth-rails_csrf_protection
   omniauth-yahoo-oauth2!
   pg (~> 1.5)
+  pg_search
   pronto
   pronto-flay
   pronto-haml

--- a/app/controllers/teachers_controller.rb
+++ b/app/controllers/teachers_controller.rb
@@ -10,10 +10,10 @@ class TeachersController < ApplicationController
   include CsvProcess
 
   before_action :load_pages, only: [:new, :create, :edit, :update]
-  before_action :load_teacher, except: [:new, :index, :create, :import, :search]
+  before_action :load_teacher, except: [:new, :index, :create, :import, :search, :cross_filter_search]
   before_action :sanitize_params, only: [:new, :create, :edit, :update]
   before_action :require_login, except: [:new, :create]
-  before_action :require_admin, only: [:validate, :deny, :destroy, :index, :show, :search]
+  before_action :require_admin, only: [:validate, :deny, :destroy, :index, :show, :search, :cross_filter_search]
   before_action :require_edit_permission, only: [:edit, :update, :resend_welcome_email]
 
   rescue_from ActiveRecord::RecordNotUnique, with: :deny_access
@@ -198,6 +198,14 @@ class TeachersController < ApplicationController
       flash[:alert] = "Error resending welcome email. Please ensure that your account has been validated by an administrator."
     end
     redirect_back(fallback_location: dashboard_path)
+  end
+
+  def cross_filter_search
+    counts = Teacher.search_non_admins(params[:q])
+      .reorder(nil)
+      .group(:application_status)
+      .count("DISTINCT teachers.id")
+    render json: counts.transform_keys { |k| Teacher.application_statuses[k] }
   end
 
   def import

--- a/app/javascript/packs/datatables.js
+++ b/app/javascript/packs/datatables.js
@@ -29,4 +29,43 @@ $(function() {
       $('[data-toggle="tooltip"]').tooltip('dispose');
       $('[data-toggle="tooltip"]').tooltip();
   });
+
+  // Cross-filter search notice: after the user stops typing for 300ms, query
+  // the server for result counts per status and surface any that are hidden
+  // by the current checkbox filter.
+  let crossFilterTimer;
+  let currentRequest = null;
+
+  function scheduleCrossFilterUpdate() {
+    clearTimeout(crossFilterTimer);
+
+    crossFilterTimer = setTimeout(function() {
+      const checked = $('input:checkbox[name="statusFilter"]:checked').map((_, el) => el.value).get();
+      const query = $tables.table('.js-teachersTable').search();
+
+      if (!query.trim() || checked.length === 0) {
+        $('#cross-filter-notice').text('');
+        return;
+      }
+
+      if (currentRequest) { currentRequest.abort(); }
+
+      currentRequest = $.get('/teachers/cross_filter_search', { q: query }, function(data) {
+        const messages = [];
+        $.each(data, function(status, count) {
+          if (!checked.includes(status)) {
+            messages.push(`${count} result(s) in ${status} \u2014 hidden by current filter`);
+          }
+        });
+        $('#cross-filter-notice').text(messages.join(' | '));
+      }).always(function() {
+        currentRequest = null;
+      }).fail(function(xhr) {
+        if (xhr.statusText !== 'abort') { $('#cross-filter-notice').text(''); }
+      });
+    }, 300);
+  }
+
+  $tables.on('search.dt', scheduleCrossFilterUpdate);
+  $('.custom-checkbox').on('change', scheduleCrossFilterUpdate);
 });

--- a/app/javascript/packs/datatables.js
+++ b/app/javascript/packs/datatables.js
@@ -54,10 +54,11 @@ $(function() {
         const messages = [];
         $.each(data, function(status, count) {
           if (!checked.includes(status)) {
-            messages.push(`${count} result(s) in ${status} \u2014 hidden by current filter`);
+            messages.push(`${count} result(s) in ${status}`);
           }
         });
-        $('#cross-filter-notice').text(messages.join(' | '));
+        const notice = messages.length > 0 ? messages.join(', ') + ' \u2014 hidden by current filter' : '';
+        $('#cross-filter-notice').text(notice);
       }).always(function() {
         currentRequest = null;
       }).fail(function(xhr) {

--- a/app/models/teacher.rb
+++ b/app/models/teacher.rb
@@ -38,6 +38,26 @@
 #  fk_rails_...  (school_id => schools.id)
 #
 class Teacher < ApplicationRecord
+  include PgSearch::Model
+
+  # Internal scope — callers use .search_non_admins which enforces admin: false.
+  # To search a new Teacher text column: add it to `against:`.
+  # To search a new association: add it to `associated_against:`.
+  pg_search_scope :_pg_search_teachers,
+    against: [:first_name, :last_name, :snap],
+    associated_against: {
+      email_addresses: :email,
+      school: :name
+    },
+    using: {
+      tsearch: { prefix: true, dictionary: "simple" },
+      trigram: { word_similarity: true }
+    }
+
+  def self.search_non_admins(query)
+    where(admin: false)._pg_search_teachers(query)
+  end
+
   # TODO: Move this somewhere else...
   WORLD_LANGUAGES = [ "Afrikaans", "Albanian", "Arabic", "Armenian", "Basque", "Bengali", "Bulgarian", "Catalan", "Cambodian", "Chinese (Mandarin)", "Croatian", "Czech", "Danish", "Dutch", "English", "Estonian", "Fiji", "Finnish", "French", "Georgian", "German", "Greek", "Gujarati", "Hebrew", "Hindi", "Hungarian", "Icelandic", "Indonesian", "Irish", "Italian", "Japanese", "Javanese", "Korean", "Latin", "Latvian", "Lithuanian", "Macedonian", "Malay", "Malayalam", "Maltese", "Maori", "Marathi", "Mongolian", "Nepali", "Norwegian", "Persian", "Polish", "Portuguese", "Punjabi", "Quechua", "Romanian", "Russian", "Samoan", "Serbian", "Slovak", "Slovenian", "Spanish", "Swahili", "Swedish ", "Tamil", "Tatar", "Telugu", "Thai", "Tibetan", "Tonga", "Turkish", "Ukrainian", "Urdu", "Uzbek", "Vietnamese", "Welsh", "Xhosa" ].freeze
 

--- a/app/models/teacher.rb
+++ b/app/models/teacher.rb
@@ -20,6 +20,7 @@
 #  session_count      :integer          default(0)
 #  snap               :string
 #  status             :integer
+#  verification_notes :text
 #  created_at         :datetime
 #  updated_at         :datetime
 #  school_id          :integer

--- a/app/views/teachers/index.html.erb
+++ b/app/views/teachers/index.html.erb
@@ -14,6 +14,8 @@
 </div>
 <% end %>
 
+<div id="cross-filter-notice" class="text-muted small mb-2"></div>
+
 <table class="table table-striped js-dataTable js-teachersTable">
   <thead class="thead-dark">
     <tr>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,10 @@ Rails.application.routes.draw do
       post :request_info
       delete "remove_file", to: "teachers#remove_file"
     end
-    collection { post :import }
+    collection do
+      post :import
+      get :cross_filter_search
+    end
   end
   resources :schools
   resources :pages, param: :url_slug

--- a/db/migrate/20260328092348_enable_pg_trgm.rb
+++ b/db/migrate/20260328092348_enable_pg_trgm.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class EnablePgTrgm < ActiveRecord::Migration[6.1]
+  def change
+    enable_extension "pg_trgm"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_04_07_190126) do
+ActiveRecord::Schema.define(version: 2026_03_28_092348) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
+  enable_extension "pg_trgm"
   enable_extension "plpgsql"
 
   create_table "action_text_rich_texts", force: :cascade do |t|

--- a/features/admin.feature
+++ b/features/admin.feature
@@ -285,6 +285,14 @@ Feature: basic admin functionality
     And I press "New Teacher"
     Then I should see "Request Access to BJC Teacher Materials"
 
+  Scenario: Cross-filter notice element is present on the teachers page
+    Given I am on the BJC home page
+    And I have an admin email
+    And I follow "Log In"
+    Then I can log in with Google
+    When I go to the teachers page
+    Then I should see hidden element "cross-filter-notice"
+
   Scenario: Admin can access new school button at teacher index page
     Given I am on the BJC home page
     Given I have an admin email

--- a/features/data_tables.feature
+++ b/features/data_tables.feature
@@ -29,6 +29,22 @@ Feature: Admin Data Tables functionality
     And I check "Validated"
     Then I should see "Bobby John"
 
+  Scenario: Cross-filter notice shows hidden matches when search spans multiple statuses
+    Given the following schools exist:
+      | name        | country | city     | state | website                  | grade_level | school_type |
+      | UC Berkeley | US      | Berkeley | CA    | https://www.berkeley.edu | university  | public      |
+    Given the following teachers exist:
+      | first_name | last_name | admin | primary_email  | school      | application_status |
+      | Alice      | Smith     | false | alice@test.edu | UC Berkeley | Validated          |
+      | Bob        | Smith     | false | bob@test.edu   | UC Berkeley | Denied             |
+    Given I am on the BJC home page
+    And I have an admin email
+    And I follow "Log In"
+    Then I can log in with Google
+    When I go to the teachers page
+    And I search the teachers table for "Smith"
+    Then I should see "result(s) in Denied"
+
   Scenario: Filter all teacher info as an admin
     Given the following schools exist:
       | name        |     country     | city     | state | website                  | grade_level | school_type |

--- a/features/data_tables.feature
+++ b/features/data_tables.feature
@@ -44,6 +44,7 @@ Feature: Admin Data Tables functionality
     When I go to the teachers page
     And I search the teachers table for "Smith"
     Then I should see "result(s) in Denied"
+    Then I should see "hidden by current filter"
 
   Scenario: Filter all teacher info as an admin
     Given the following schools exist:

--- a/features/step_definitions/page_steps.rb
+++ b/features/step_definitions/page_steps.rb
@@ -20,7 +20,7 @@ When("I check {string} checkbox") do |checkbox|
 end
 
 When(/^I search the teachers table for "([^"]*)"$/) do |query|
-  first('.dataTables_filter input').set(query)
+  first(".dataTables_filter input").set(query)
 end
 
 When(/^(?:|I )fill in the page HTML content with "([^"]*)"$/) do |value|

--- a/features/step_definitions/page_steps.rb
+++ b/features/step_definitions/page_steps.rb
@@ -19,6 +19,10 @@ When("I check {string} checkbox") do |checkbox|
   check checkbox
 end
 
+When(/^I search the teachers table for "([^"]*)"$/) do |query|
+  first('.dataTables_filter input').set(query)
+end
+
 When(/^(?:|I )fill in the page HTML content with "([^"]*)"$/) do |value|
   page.execute_script('$(tinyMCE.editors[0].setContent("' + value + '"))')
 end

--- a/spec/controllers/teachers_controller_spec.rb
+++ b/spec/controllers/teachers_controller_spec.rb
@@ -273,6 +273,46 @@ RSpec.describe TeachersController, type: :controller do
     end
   end
 
+  describe "GET #cross_filter_search" do
+    before do
+      ApplicationController.any_instance.stub(:require_admin).and_return(true)
+    end
+
+    context "action is reachable" do
+      it "responds with 200 OK" do
+        get :cross_filter_search, params: { q: "anything" }
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "responds with JSON content type" do
+        get :cross_filter_search, params: { q: "anything" }
+        expect(response.content_type).to match(%r{application/json})
+      end
+    end
+
+    context "returns status counts as display values" do
+      before do
+        fake_relation = double("ActiveRecord::Relation")
+        allow(Teacher).to receive(:search_non_admins).and_return(fake_relation)
+        allow(fake_relation).to receive(:reorder).and_return(fake_relation)
+        allow(fake_relation).to receive(:group).and_return(fake_relation)
+        allow(fake_relation).to receive(:count).and_return({ "denied" => 2, "validated" => 1 })
+      end
+
+      it "returns display values as keys in the JSON response" do
+        get :cross_filter_search, params: { q: "test" }
+        body = JSON.parse(response.body)
+        expect(body).to eq({ "Denied" => 2, "Validated" => 1 })
+      end
+
+      it "omits statuses with zero count" do
+        get :cross_filter_search, params: { q: "test" }
+        body = JSON.parse(response.body)
+        expect(body.keys).not_to include("Info Needed", "Not Reviewed")
+      end
+    end
+  end
+
   describe "GET #edit" do
     let(:teacher) { instance_double("Teacher", id: 1, school:) }
     let(:school) { instance_double("School") }

--- a/spec/factories/teachers.rb
+++ b/spec/factories/teachers.rb
@@ -20,6 +20,7 @@
 #  session_count      :integer          default(0)
 #  snap               :string
 #  status             :integer
+#  verification_notes :text
 #  created_at         :datetime
 #  updated_at         :datetime
 #  school_id          :integer

--- a/spec/fixtures/teachers.yml
+++ b/spec/fixtures/teachers.yml
@@ -18,6 +18,7 @@
 #  session_count      :integer          default(0)
 #  snap               :string
 #  status             :integer
+#  verification_notes :text
 #  created_at         :datetime
 #  updated_at         :datetime
 #  school_id          :integer

--- a/spec/models/email_template_spec.rb
+++ b/spec/models/email_template_spec.rb
@@ -1,5 +1,23 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: email_templates
+#
+#  id         :bigint           not null, primary key
+#  body       :text
+#  format     :string
+#  handler    :string
+#  locale     :string
+#  partial    :boolean
+#  path       :string
+#  required   :boolean          default(FALSE)
+#  subject    :string
+#  title      :string
+#  to         :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
 require "rails_helper"
 
 RSpec.describe EmailTemplate, type: :model do

--- a/spec/models/teacher_spec.rb
+++ b/spec/models/teacher_spec.rb
@@ -131,4 +131,42 @@ RSpec.describe Teacher, type: :model do
       expect(teacher.display_application_status).to eq "Not Reviewed"
     end
   end
+
+  describe ".search_non_admins" do
+    it "finds teacher by first name" do
+      expect(Teacher.search_non_admins("bob")).to include(teachers(:bob))
+    end
+
+    it "finds teacher by last name" do
+      expect(Teacher.search_non_admins("hakurei")).to include(teachers(:reimu))
+    end
+
+    it "finds teacher by email" do
+      expect(Teacher.search_non_admins("bob@gmail")).to include(teachers(:bob))
+    end
+
+    it "finds teacher by snap username" do
+      # long fixture has snap: "song"
+      expect(Teacher.search_non_admins("song")).to include(teachers(:long))
+    end
+
+    it "finds teachers by school name" do
+      results = Teacher.search_non_admins("berkeley")
+      expect(results).to include(teachers(:bob), teachers(:barney))
+    end
+
+    it "excludes admin teachers" do
+      # "Wang" is admin's last name and unique to that fixture —
+      # if admin is not excluded, this would return a result; it should be empty
+      expect(Teacher.search_non_admins("Wang")).to be_empty
+    end
+
+    it "returns empty when nothing matches" do
+      expect(Teacher.search_non_admins("zzznomatch999")).to be_empty
+    end
+
+    it "is case-insensitive" do
+      expect(Teacher.search_non_admins("BOB")).to include(teachers(:bob))
+    end
+  end
 end

--- a/spec/models/teacher_spec.rb
+++ b/spec/models/teacher_spec.rb
@@ -20,6 +20,7 @@
 #  session_count      :integer          default(0)
 #  snap               :string
 #  status             :integer
+#  verification_notes :text
 #  created_at         :datetime
 #  updated_at         :datetime
 #  school_id          :integer


### PR DESCRIPTION
Feature to show hidden results when searching; it is deployed to Heroku for testing.
- Ask Michael about notice text placement.
- Filtered results on role omitted since future feature will remove this column for a course column and it makes the code simpler.
- Deployed to Heroku for testing.

NOTE: large commit number is due to other features not yet merged into golden repo, so history is behind.

<img width="1512" height="389" alt="image" src="https://github.com/user-attachments/assets/a281756f-9be2-415c-b49e-06481af1c0d9" />
