### PR TITLE
Iteration 3 - Redirect admin to intended page after login

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -26,15 +26,22 @@ class ApplicationController < ActionController::Base
 
   def require_login
     unless logged_in?
-      flash[:danger] = "You need to log in to access this."
-      redirect_to root_path
+      session[:redirect_on_login] = request.path
+      flash[:danger] = "Please log in to access this page."
+      redirect_to login_path
     end
   end
 
   def require_admin
     unless is_admin?
-      flash[:danger] = "Only admins can access this page."
-      redirect_to root_path
+      if !logged_in?
+        session[:redirect_on_login] = request.path
+        flash[:danger] = "Please log in to access this page."
+        redirect_to login_path
+      else
+        flash[:danger] = "Only admins can access this page."
+        redirect_to root_path
+      end
     end
   end
 

--- a/features/access.feature
+++ b/features/access.feature
@@ -74,39 +74,46 @@ Scenario: Try to access merge page as a registered teacher
   When I go to the merge preview page for Todd into Alice
   Then I should see "Only admins can access this page"
 
+#Unauthenticated Admin
+Scenario: Admin is redirected to intended page after login
+  Given I have an admin email
+  Given I am on the admin dashboard
+  Then I can log in with Google
+  Then I should be on the admin dashboard
+
 #New User
 Scenario: Schools page as a new user
   Given I am on the schools page
-  Then I should be on the new teachers page
+  Then I should be on the login page
 
 Scenario: Dashboard page as a new user
   Given I am on the admin dashboard
-  Then I should be on the new teachers page
+  Then I should be on the login page
 
 Scenario: New School page as a new user
   Given I am on the new schools page
-  Then I should be on the new teachers page
+  Then I should be on the login page
 
 Scenario: All teacher page as a new user
   Given I am on the teachers page
-  Then I should be on the new teachers page
+  Then I should be on the login page
 
 Scenario: Email templates page as a new user
   Given I am on the email templates index
-  Then I should be on the new teachers page
+  Then I should be on the login page
 
 Scenario: admin user's edit page as a new user
   Given I am on the edit page for Alice Admin
-  Then I should be on the new teachers page
+  Then I should be on the login page
 
 Scenario: admin user's show page as a new user
   Given I am on the show page for Alice Admin
-  Then I should be on the new teachers page
+  Then I should be on the login page
 
 Scenario: Other user's edit page as a new user
   Given I am on the edit page for Todd Teacher
-  Then I should be on the new teachers page
+  Then I should be on the login page
 
 Scenario: Other user's show page as a new user
   Given I am on the show page for Todd Teacher
-  Then I should be on the new teachers page
+  Then I should be on the login page

--- a/features/admin.feature
+++ b/features/admin.feature
@@ -71,8 +71,8 @@ Feature: basic admin functionality
     Given I have a non-admin, unregistered Google email
     Given I am on the BJC home page
     When  I go to the dashboard page
-    Then  I should see "Only admins can access this page"
-    And   I should be on the new teachers page
+    Then  I should see "Please log in to access this page"
+    And   I should be on the login page
 
   Scenario: Edit teacher info as an admin
     Given the following schools exist:
@@ -212,7 +212,7 @@ Feature: basic admin functionality
       | first_name | last_name | admin | primary_email            | school      |
       | Joseph     | Mamoa     | false | testteacher@berkeley.edu | UC Berkeley |
     When  I go to the edit page for Joseph Mamoa
-    Then  should see "You need to log in to access this."
+    Then  should see "Please log in to access this page"
 
   Scenario: View teacher info as an admin
     Given the following schools exist:

--- a/spec/controllers/teachers_controller_spec.rb
+++ b/spec/controllers/teachers_controller_spec.rb
@@ -158,8 +158,8 @@ RSpec.describe TeachersController, type: :controller do
     it "does not allow non-admin to accept a user" do
       post :validate, params: { id: 1 }
       expect(response).to have_http_status(302)
-      expect(response).to redirect_to(root_path)
-      expect(flash[:danger]).to eq "Only admins can access this page."
+      expect(response).to redirect_to(login_path)
+      expect(flash[:danger]).to eq "Please log in to access this page."
     end
 
     it "rejects malicious admin signup attempt" do


### PR DESCRIPTION
Feature: if an admin attempts to view a page requiring admin permissions and is not logged in, we should redirect them to the page they intended to view after a successful login.
- Deployed to Heroku for testing.

NOTE: large commit number is due to other features not yet merged into golden repo, so history is behind.
