### PR TITLE
Iteration 3 - When Searching w/ a Filter, UI should Indicate Hidden Results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,6 @@ cc-test-reporter
 
 # CSV data files
 *.csv
+
+*.claude/
+CLAUDE.md

--- a/app/javascript/packs/datatables.js
+++ b/app/javascript/packs/datatables.js
@@ -1,3 +1,37 @@
+function countHiddenResults(table, statusColIdx, searchQuery, statusValue) {
+  if (!searchQuery) return 0;
+  const terms = searchQuery.toLowerCase().trim().split(/\s+/).filter(Boolean);
+  let count = 0;
+  table.rows().every(function() {
+    const cache = this.cache('search');
+    if (cache[statusColIdx] !== statusValue) return;
+    const rowText = cache.join(' ').toLowerCase();
+    if (terms.every(term => rowText.includes(term))) count++;
+  });
+  return count;
+}
+
+function updateHiddenResultsNotice(table, statusColIdx) {
+  const searchQuery = table.search().trim();
+  const $notice = $('#hidden-filter-notice');
+  const $allBoxes = $('input:checkbox[name="statusFilter"]');
+  const checkedCount = $allBoxes.filter(':checked').length;
+
+  if (!searchQuery || checkedCount === 0 || checkedCount === $allBoxes.length) {
+    $notice.text('');
+    return;
+  }
+
+  const parts = [];
+  $allBoxes.not(':checked').each(function() {
+    const label = $('label[for="' + this.id + '"]').text().trim();
+    const count = countHiddenResults(table, statusColIdx, searchQuery, this.value);
+    if (count > 0) parts.push(count + ' result(s) in ' + label);
+  });
+
+  $notice.text(parts.length > 0 ? parts.join(', ') + ' — hidden by current filter' : '');
+}
+
 $(function() {
   // Filtering for the Admin Teachers Index
   $.fn.dataTable.ext.search.push((_, searchData) => {
@@ -22,11 +56,19 @@ $(function() {
   });
 
   $tables.draw();
+
+  const statusColIdx = $('td[data-col="status"]').first().index();
+  const $noticeEl = $('<div id="hidden-filter-notice" class="small text-muted w-100"></div>');
+  $($tables.table().container()).find('.dataTables_info').closest('.col-6').append($noticeEl);
+
+  const $teachersTable = $('.js-teachersTable').DataTable();
+
   $(".custom-checkbox").on("change", () => {
       $tables.draw();
   });
   $tables.on('draw', function() {
       $('[data-toggle="tooltip"]').tooltip('dispose');
       $('[data-toggle="tooltip"]').tooltip();
+      updateHiddenResultsNotice($teachersTable, statusColIdx);
   });
 });

--- a/features/data_tables.feature
+++ b/features/data_tables.feature
@@ -29,6 +29,27 @@ Feature: Admin Data Tables functionality
     And I check "Validated"
     Then I should see "Bobby John"
 
+  Scenario: Show hidden results notice when searching with an active status filter
+    Given the following schools exist:
+      | name        | country | city     | state | website                  | grade_level | school_type |
+      | UC Berkeley | US      | Berkeley | CA    | https://www.berkeley.edu | university  | public      |
+    Given the following teachers exist:
+      | first_name | last_name  | admin | primary_email             | school      | application_status |
+      | Victor     | Validateme | false | testteacher1@berkeley.edu | UC Berkeley | Validated          |
+      | Danny      | Denyme     | false | testteacher2@berkeley.edu | UC Berkeley | Denied             |
+      | Peter      | Pendme     | false | testteacher3@berkeley.edu | UC Berkeley | Not Reviewed       |
+    Given I am on the BJC home page
+    Given I have an admin email
+    And   I follow "Log In"
+    Then  I can log in with Google
+    When  I go to the teachers page
+    And   I fill in the teachers table search with "me"
+    Then  I should see "1 result(s) in Denied, 1 result(s) in Not Reviewed — hidden by current filter"
+    And   I check "Denied"
+    Then  I should see "1 result(s) in Not Reviewed — hidden by current filter"
+    And   I check "Not Reviewed"
+    Then  I should not see "hidden by current filter"
+
   Scenario: Filter all teacher info as an admin
     Given the following schools exist:
       | name        |     country     | city     | state | website                  | grade_level | school_type |

--- a/features/step_definitions/table_steps.rb
+++ b/features/step_definitions/table_steps.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+When(/^I fill in the teachers table search with "([^"]*)"$/) do |value|
+  first(".js-teachersTable").ancestor(".dataTables_wrapper").find(".dataTables_filter input").set(value)
+end
+
 Given(/^I should see "(.*)" with "(.*)" in a table row$/) do |field_1, field_2|
   both = false
   page.find_all("tr").each do |table_row|


### PR DESCRIPTION
## Summary
- When searching the teachers table with some status checkboxes unchecked, a notice now appears directly below the "Showing X to Y of Z entries" line indicating how many matching records are hidden by the current filter (e.g. `1 result(s) in Denied, 2 result(s) in Not Reviewed — hidden by current filter`)
- <img width="1503" height="198" alt="image" src="https://github.com/user-attachments/assets/f31c41c5-7c8d-4c8d-9c52-8c76196dace5" />



## Implementation Notes
- `app/javascript/packs/datatables.js:` Uses DataTables' public `row().cache('search')` API to count against pre-computed in-memory search data then injects notice text below the main results text
- `features/step_definitions/table_steps.rb:` Adds a new step definition that only populates the search for the teachers table, since the teachers index has both the teachers and admins tables

## Testing
- Simple cucumber test included to make sure notice text appears with correct counts
- Deployed to Heroku: https://sp26-03-bjc-c7c152ebb984.herokuapp.com/teachers

@cycomachead @armandofox @mdawn65