### PR TITLE
Fix flakey cucumber specs

### DIFF
--- a/features/step_definitions/admin_steps.rb
+++ b/features/step_definitions/admin_steps.rb
@@ -93,8 +93,11 @@ end
 
 Then(/I attach the csv "([^"]*)"$/) do |path|
   Capybara.ignore_hidden_elements = false
-  attach_file("file", File.expand_path(path))
-  Capybara.ignore_hidden_elements = true
+  begin
+    attach_file("file", File.expand_path(path))
+  ensure
+    Capybara.ignore_hidden_elements = true
+  end
 end
 
 Then(/I send a request info email with content "(.*)"/) do |content|

--- a/features/step_definitions/email_addresses_steps.rb
+++ b/features/step_definitions/email_addresses_steps.rb
@@ -33,12 +33,14 @@ When(/^I clear the email input$/) do
 end
 
 When(/^I close the email modal$/) do
-  within("#emailModal") do
-    find(".modal-header").click
-    sleep 0.2
-    find("button.close span").click
-  end
-  expect(page).not_to have_css(".modal-backdrop", wait: 5)
+  # Trigger Bootstrap's modal-dismiss behavior directly. Clicking the close
+  # button via Capybara is unreliable while the email input still has focus
+  # (browsers run native required-field validation on blur, which races the
+  # click). Using the public Bootstrap API both blurs inputs and animates the
+  # modal closed in one deterministic step.
+  page.execute_script("$('#emailModal').modal('hide')")
+  expect(page).not_to have_css("#emailModal.show")
+  expect(page).not_to have_css(".modal-backdrop")
 end
 
 When(/^I click the delete button for email "([^"]*)"$/) do |email|

--- a/features/step_definitions/form_steps.rb
+++ b/features/step_definitions/form_steps.rb
@@ -24,26 +24,25 @@ Given(/^I set my application status as "(.*)"$/) do |input|
   select(input, from: "application_status_select_value")
 end
 
-# assumes that languages dropdown is the FIRST selectize menu to appear on the page
-When(/^I select "(.*?)" from the languages dropdown$/) do |option|
-  first(".selectize-input").click # Click on the dropdown to open it
-  find(".selectize-dropdown-content .option", text: option).click  # Click on the desired option
+# Locates the selectize widget that wraps the teacher#languages <select>.
+# The school selectize on the same form also renders a `.selectize-input`,
+# so anchoring to the languages select element by id keeps this stable
+# regardless of which widget initializes first.
+def languages_selectize
+  find("#teacher_languages", visible: :all).find(:xpath, "./following-sibling::div[contains(@class, 'selectize-control')][1]//div[contains(@class, 'selectize-input')]")
 end
 
-# also assumes that languages dropdown is the FIRST selectize menu to appear on the page
+When(/^I select "(.*?)" from the languages dropdown$/) do |option|
+  languages_selectize.click
+  find(".selectize-dropdown.active .selectize-dropdown-content .option", text: option).click
+end
+
 When(/^I remove "(.*?)" from the languages dropdown$/) do |item|
-  first(".selectize-input .item", text: item).find(".remove").click
+  languages_selectize.find(".item", text: item).find(".remove").click
 end
 
 Then(/^the languages dropdown should have the option "(.*?)" selected$/) do |selected_option|
-  # Find the Selectize dropdown by its CSS class
-  selectize_dropdown = first(".selectize-input")
-
-  # Find the selected option within the dropdown
-  selected_option_element = selectize_dropdown.find(".item", text: selected_option)
-
-  # Assert that the selected option exists
-  expect(selected_option_element).to be_visible
+  expect(languages_selectize.find(".item", text: selected_option)).to be_visible
 end
 
 Given(/^I set my request reason as "(.*)"$/) do |input|

--- a/features/step_definitions/page_steps.rb
+++ b/features/step_definitions/page_steps.rb
@@ -20,10 +20,16 @@ When("I check {string} checkbox") do |checkbox|
 end
 
 When(/^(?:|I )fill in the page HTML content with "([^"]*)"$/) do |value|
-  page.execute_script('$(tinyMCE.editors[0].setContent("' + value + '"))')
+  Timeout.timeout(Capybara.default_max_wait_time) do
+    sleep 0.05 until page.evaluate_script("typeof tinyMCE !== 'undefined' && tinyMCE.editors && tinyMCE.editors.length > 0")
+  end
+  page.execute_script("tinyMCE.editors[0].setContent(#{value.to_json})")
 end
 
 And(/^(?:|I )should see the page HTML content containing "([^"]*)"$/) do |value|
+  Timeout.timeout(Capybara.default_max_wait_time) do
+    sleep 0.05 until page.evaluate_script("typeof tinyMCE !== 'undefined' && tinyMCE.editors && tinyMCE.editors.length > 0")
+  end
   expect(page.execute_script("return tinyMCE.editors[0].getContent()")).to include(value)
 end
 

--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -57,7 +57,13 @@ When(/^(?:|I )fill in "([^"]*)" with "([^"]*)"$/) do |field, value|
 end
 
 When(/^(?:|I )fill in TinyMCE email form with "([^"]*)"$/) do |value|
-  page.execute_script('$(tinymce.editors[0].setContent("' + value + '"))')
+  # TinyMCE initializes asynchronously after the page renders, so editors[0]
+  # can be undefined when the step first runs. Poll until at least one editor
+  # is registered before setting content.
+  Timeout.timeout(Capybara.default_max_wait_time) do
+    sleep 0.05 until page.evaluate_script("typeof tinymce !== 'undefined' && tinymce.editors && tinymce.editors.length > 0")
+  end
+  page.execute_script("tinymce.editors[0].setContent(#{value.to_json})")
 end
 
 When(/^(?:|I )follow the first "([^"]*)" link$/) do |link_text|
@@ -128,9 +134,14 @@ Then(/^(?:|I )should see "([^"]*)"$/) do |text|
 end
 
 Then(/^(?:|I )should see hidden element "([^"]*)"$/) do |text|
+  # Use ensure so a failed assertion can't leave the global flag flipped and
+  # poison later scenarios that expect the default (true).
   Capybara.ignore_hidden_elements = false
-  expect(page.html).to match(/#{text}/)
-  Capybara.ignore_hidden_elements = true
+  begin
+    expect(page.html).to match(/#{text}/)
+  ensure
+    Capybara.ignore_hidden_elements = true
+  end
 end
 
 Then(/^(?:|I )should see \/([^\/]*)\/$/) do |regexp|

--- a/features/support/browsers.rb
+++ b/features/support/browsers.rb
@@ -50,8 +50,10 @@ Capybara.register_driver :chrome do |app|
 end
 
 Capybara.register_driver :headless_chrome do |app|
-  chrome_options.add_argument("--headless")
+  chrome_options.add_argument("--headless=new")
   chrome_options.add_argument("--disable-gpu")
+  chrome_options.add_argument("--no-sandbox")
+  chrome_options.add_argument("--disable-dev-shm-usage")
   chrome_options.add_argument("--window-size=1440,900")
 
   driver = Capybara::Selenium::Driver.new(app, browser: :chrome, options: chrome_options)
@@ -96,4 +98,9 @@ Capybara.register_driver :headless_firefox do |app|
 end
 
 Capybara.default_driver = select_capybara_driver
+# Headless Chrome on CI is consistently slower than the 2s default. Bumping
+# this to 10s prevents Selenium-driven assertions and finders from racing
+# JavaScript that initializes asynchronously (DataTables, TinyMCE, Selectize,
+# Bootstrap modals, OmniAuth-mocked redirects).
+Capybara.default_max_wait_time = 10
 puts "\nRUNNING CAPYBARA WITH DRIVER #{Capybara.default_driver}\n\n"


### PR DESCRIPTION
### [Pivotal Tracker Link][tracker]

[tracker]: https://www.pivotaltracker.com/story/show/your-story-id

## What this PR does:

This pull request fixes flaky Cucumber/Capybara specs that were intermittently failing in CI due to race conditions between test steps and asynchronous JavaScript initialization.

### How should this PR be tested?

* Run the full Cucumber suite in CI (headless Chrome) and verify that previously flaky specs pass consistently across multiple runs.
* Key scenarios to watch: email modal close, TinyMCE content fill/read, languages dropdown select/remove, CSV file attachment, and hidden element assertions.

**Root causes addressed:**

- **Slow JS initialization** — `Capybara.default_max_wait_time` bumped from 2s to 10s to give DataTables, TinyMCE, Selectize, and Bootstrap modals time to initialize under CI load.
- **Headless Chrome flags** — Switched `--headless` to `--headless=new`; added `--no-sandbox` and `--disable-dev-shm-usage` for better CI resource handling.
- **Email modal close** — Replaced fragile `sleep 0.2` + click sequence with a direct Bootstrap `$('#emailModal').modal('hide')` API call, eliminating the race between required-field validation and the close button click.
- **TinyMCE race condition** — Added a poll loop that waits for `tinymce.editors.length > 0` before calling `setContent`, preventing `undefined` errors on async editor initialization.
- **Ambiguous Selectize lookups** — Scoped languages dropdown steps to `#teacher_languages` by ID rather than `first(".selectize-input")`, which was matching the school selectize widget on the same form.
- **State leakage between scenarios** — Wrapped `Capybara.ignore_hidden_elements = false` blocks in `begin/ensure` so a failing assertion can't leave the flag flipped and corrupt subsequent scenarios.

#### Are there any complications to deploying this?

No — test-only changes with no impact on application code.

### Checklist:

- [ ] Has this been deployed to a staging environment or reviewed by a customer?
- [ ] Tag someone for code review (either a coach / team member)
- [ ] I have renamed the branch to match PivotTracker's suggested one (necessary for BlueJay) (e.g. `michael/12345-add-new-feature` Any branch name will do as long as the story ID is there. You can use `git checkout -b [new-branch-name]`)

---

[Superconductor Ticket Implementation](https://www.superconductor.com/tickets/PrzChfnJjWQ9/implementations/RBdrckMrBcjH) | [App Preview](https://www.superconductor.com/tickets/PrzChfnJjWQ9/implementations/RBdrckMrBcjH/preview) | [Guided Review](https://www.superconductor.com/tickets/PrzChfnJjWQ9/implementations/RBdrckMrBcjH?tab=guided_review)

<!-- created-by-superconductor -->