### PR TITLE
Iteration 3 - View teacher url to the form submission email and RSPEC

### DIFF
--- a/app/mailers/teacher_mailer.rb
+++ b/app/mailers/teacher_mailer.rb
@@ -62,21 +62,10 @@ class TeacherMailer < ApplicationMailer
       denial_reason: @denial_reason,
       request_reason: @request_reason,
       request_info_reason: @request_reason,
-      view_teacher_url: teacher_show_url
+      view_teacher_url: teacher_url(@teacher)
     }
     base_rules.merge!(@teacher.email_attributes)
     base_rules.with_indifferent_access
-  end
-
-  def teacher_show_url
-    Rails.application.routes.url_helpers.teacher_url(@teacher, **url_options_for_mailer)
-  end
-
-  def url_options_for_mailer
-    default_options = ActionMailer::Base.default_url_options || {}
-    return default_options if default_options[:host].present?
-
-    { host: "127.0.0.1", port: 3000, protocol: "http" }
   end
 
   def email_template

--- a/app/mailers/teacher_mailer.rb
+++ b/app/mailers/teacher_mailer.rb
@@ -61,10 +61,22 @@ class TeacherMailer < ApplicationMailer
       piazza_password: Rails.application.secrets[:piazza_password],
       denial_reason: @denial_reason,
       request_reason: @request_reason,
-      request_info_reason: @request_reason
+      request_info_reason: @request_reason,
+      view_teacher_url: teacher_show_url
     }
     base_rules.merge!(@teacher.email_attributes)
     base_rules.with_indifferent_access
+  end
+
+  def teacher_show_url
+    Rails.application.routes.url_helpers.teacher_url(@teacher, **url_options_for_mailer)
+  end
+
+  def url_options_for_mailer
+    default_options = ActionMailer::Base.default_url_options || {}
+    return default_options if default_options[:host].present?
+
+    { host: "127.0.0.1", port: 3000, protocol: "http" }
   end
 
   def email_template

--- a/app/views/email_templates/_liquid_fields.erb
+++ b/app/views/email_templates/_liquid_fields.erb
@@ -27,5 +27,9 @@
       <td><code>{{request_reason}}</code></td>
       <td>(Only on request emails.)</td>
     </tr>
+    <tr>
+      <td><code>{{view_teacher_url}}</code></td>
+      <td>(Link to the teacher submission page.)</td>
+    </tr>
   </tbody>
 </table>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -36,8 +36,10 @@ Rails.application.configure do
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.delivery_method = :letter_opener_web
   config.action_mailer.perform_deliveries = true
+  config.action_mailer.default_url_options = { host: "localhost", port: 3000, protocol: "http" }
 
   config.action_mailer.perform_caching = false
+  Rails.application.routes.default_url_options = config.action_mailer.default_url_options
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -93,6 +93,12 @@ Rails.application.configure do
   # Set this to true and configure the email server for immediate delivery to raise delivery rors.
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.delivery_method = :smtp
+  config.action_mailer.default_url_options = {
+    host: ENV.fetch("APP_HOST", "teachers.bjc.berkeley.edu"),
+    protocol: ENV.fetch("APP_PROTOCOL", "https")
+  }
+  config.action_mailer.default_url_options[:port] = ENV["APP_PORT"].to_i if ENV["APP_PORT"].present?
+  Rails.application.routes.default_url_options = config.action_mailer.default_url_options
   config.action_mailer.smtp_settings = {
     address: ENV["SMTP_EMAIL_ADDRESS"],
     port: 587,

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -91,6 +91,12 @@ Rails.application.configure do
   # Email settings
   # Do not send emails in staging environment, and do not raise errors
   config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.default_url_options = {
+    host: ENV.fetch("APP_HOST", "teachers.bjc.berkeley.edu"),
+    protocol: ENV.fetch("APP_PROTOCOL", "https")
+  }
+  config.action_mailer.default_url_options[:port] = ENV["APP_PORT"].to_i if ENV["APP_PORT"].present?
+  Rails.application.routes.default_url_options = config.action_mailer.default_url_options
 
   # Store files on Amazon S3. (Uncomment this when S3 is setup)
   # config.active_storage.service = :amazon

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -39,6 +39,8 @@ Rails.application.configure do
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
+  config.action_mailer.default_url_options = { host: "localhost", port: 3000, protocol: "http" }
+  Rails.application.routes.default_url_options = config.action_mailer.default_url_options
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr

--- a/db/seed_data.rb
+++ b/db/seed_data.rb
@@ -15,6 +15,7 @@ module SeedData
 
   @form_submission = <<-FORM_SUBMISSION
     <p>
+      View form submission {{view_teacher_url}}<br>
       Here is the information that was submitted: <br>
       Name: {{teacher_first_name}} {{teacher_last_name}} <br>
       Email: {{teacher_email}} <br>

--- a/spec/mailers/teacher_mailer_spec.rb
+++ b/spec/mailers/teacher_mailer_spec.rb
@@ -6,7 +6,6 @@ describe TeacherMailer do
   fixtures :all
 
   before(:all) do
-    ActionMailer::Base.default_url_options = { host: "127.0.0.1", port: 3000, protocol: "http" }
     Rails.application.load_seed
   end
   it "Sends Welcome Email" do
@@ -56,7 +55,7 @@ describe TeacherMailer do
     email = TeacherMailer.form_submission(teacher)
     email.deliver_now
 
-    expect(email.body.encoded).to include("http://127.0.0.1:3000/teachers/#{teacher.id}")
+    expect(email.body.encoded).to include(Rails.application.routes.url_helpers.teacher_url(teacher))
     expect(email.body.encoded).not_to include("{{view_teacher_url}}")
   end
 

--- a/spec/mailers/teacher_mailer_spec.rb
+++ b/spec/mailers/teacher_mailer_spec.rb
@@ -4,7 +4,9 @@ require "rails_helper"
 
 describe TeacherMailer do
   fixtures :all
+
   before(:all) do
+    ActionMailer::Base.default_url_options = { host: "127.0.0.1", port: 3000, protocol: "http" }
     Rails.application.load_seed
   end
   it "Sends Welcome Email" do
@@ -45,7 +47,17 @@ describe TeacherMailer do
     email.deliver_now
     expect(email.from).to include("contact@bjc.berkeley.edu")
     expect(email.to).to include("lmock@berkeley.edu")
+    expect(email.body.encoded).to include("View form submission")
     expect(email.body.encoded).to include("Short Long")
+  end
+
+  it "renders view_teacher_url in Form Submission email" do
+    teacher = teachers(:long)
+    email = TeacherMailer.form_submission(teacher)
+    email.deliver_now
+
+    expect(email.body.encoded).to include("http://127.0.0.1:3000/teachers/#{teacher.id}")
+    expect(email.body.encoded).not_to include("{{view_teacher_url}}")
   end
 
   it "Sends Request Info Email" do

--- a/spec/mailers/teacher_mailer_spec.rb
+++ b/spec/mailers/teacher_mailer_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 describe TeacherMailer do
   fixtures :all
 
-  before(:all) do
+  before(:each) do
     Rails.application.load_seed
   end
   it "Sends Welcome Email" do

--- a/spec/views/email_templates/liquid_fields_spec.rb
+++ b/spec/views/email_templates/liquid_fields_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "email_templates/_liquid_fields.erb", type: :view do
+  it "includes view_teacher_url in the allowed tags list" do
+    allow(view).to receive(:current_user).and_return(
+      double(email_attributes: { teacher_first_name: "Test" })
+    )
+
+    render partial: "email_templates/liquid_fields"
+
+    expect(rendered).to include("{{view_teacher_url}}")
+  end
+end


### PR DESCRIPTION
This is a copy of https://github.com/cs169/BJC-Teacher-Tracker/pull/111 from the local repo with issues from the comments resolved. @NishK05's work.

What it does:
Adds View Teacher URL to form submission email template and rspec test for it.

<img width="1168" height="513" alt="image" src="https://github.com/user-attachments/assets/ac830012-d955-45a7-9d2d-a0efecc03734" />


<img width="1168" height="51" alt="image" src="https://github.com/user-attachments/assets/617731d3-12be-4d8d-abd4-11fca0ae29cd" />

@cycomachead @armandofox @mdawn65