### PR TITLE
Test Fix: features/pages_admin.feature:233

### DIFF
--- a/features/pages_admin.feature
+++ b/features/pages_admin.feature
@@ -237,6 +237,7 @@ Scenario: Attempting to update page with taken slug doesn't delete form input
     And I choose "inlineRadioAdmin"
     And I fill in the page HTML content with "This is a test"
     And I press "Submit"
+    And I wait for TinyMCE to load
     Given I am on the new pages page
     And I fill in "page_title" with "Test Title 2"
     And I fill in "page_url_slug" with "basic_slug_2"

--- a/features/step_definitions/debug_steps.rb
+++ b/features/step_definitions/debug_steps.rb
@@ -22,7 +22,7 @@ And (/^Show me full page html$/) do
   puts page.html
 end
 
-# views/pages/_form.html.erb has a TinyMCE script that 
+# views/pages/_form.html.erb has a TinyMCE script that
 # will cause broswer to hang due to loading assets
 And (/^I wait for TinyMCE to load$/) do
   sleep 1

--- a/features/step_definitions/debug_steps.rb
+++ b/features/step_definitions/debug_steps.rb
@@ -21,3 +21,9 @@ end
 And (/^Show me full page html$/) do
   puts page.html
 end
+
+# views/pages/_form.html.erb has a TinyMCE script that 
+# will cause broswer to hang due to loading assets
+And (/^I wait for TinyMCE to load$/) do
+  sleep 1
+end


### PR DESCRIPTION
The TinyMCE script in `views/pages/_form.html.erb` causes some tests to timeout usually after a page reload, since the script loads some assets causing some weird interactions with Chromedriver, which I am not entirely sure of how it works. The fix is a simple wait.

The TinyMCE script may be the cause of the other failing tests in `features/pages_admin.feature`. If I notice that a lot of tests are failing due to this script, I'll refactor it and any associated code.

@cycomachead 